### PR TITLE
fix: docker-compose-plugin should conflict with all docker-compose versions

### DIFF
--- a/debian-compose/control
+++ b/debian-compose/control
@@ -11,9 +11,9 @@ Package: docker-compose-plugin
 Architecture: riscv64
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Recommends: docker-cli
-Conflicts: docker-compose (<< 2.0)
-Replaces: docker-compose (<< 2.0)
-Breaks: docker-compose (<< 2.0)
+Conflicts: docker-compose
+Replaces: docker-compose
+Breaks: docker-compose
 Provides: docker-compose
 Description: Docker Compose v2 plugin for RISC-V64
  Docker Compose is a tool for running multi-container applications on


### PR DESCRIPTION
## Summary

Fixed package conflict declaration to ensure docker-compose-plugin properly replaces all versions of docker-compose package.

## Problem

The docker-compose-plugin control file had:
```
Conflicts: docker-compose (<< 2.0)
Replaces: docker-compose (<< 2.0)
Breaks: docker-compose (<< 2.0)
```

This only conflicts with docker-compose versions < 2.0, but the current Debian docker-compose package is 2.26.1. Both packages create `/usr/bin/docker-compose`, causing potential file conflicts if both are installed.

## Solution

Changed to unconditional conflict matching Docker's official package relationships:
```
Conflicts: docker-compose
Replaces: docker-compose
Breaks: docker-compose
```

## Impact

- Users can install either docker-compose OR docker-compose-plugin (not both)
- Installing docker-compose-plugin will replace any existing docker-compose package
- Our version (2.40.1) is newer than Debian's (2.26.1)
- Prevents file conflicts at /usr/bin/docker-compose

## Testing

After this change is merged and a new package is built, users should be able to:
```bash
# If docker-compose is installed
sudo apt-get install docker-compose-plugin  # Should replace docker-compose

# If docker-compose-plugin is installed
sudo apt-get install docker-compose  # Should fail with conflict error
```

## References

- Issue: File conflict between docker-compose packages
- Pattern: Matches official Docker repository package relationships

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependency constraints for broader system compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->