### PR TITLE
feat: add automatic Docker CLI release tracking

### DIFF
--- a/.github/workflows/track-cli-releases.yml
+++ b/.github/workflows/track-cli-releases.yml
@@ -6,6 +6,11 @@ on:
     - cron: '0 7 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+  actions: write
+
 jobs:
   check-release:
     runs-on: [self-hosted, riscv64]
@@ -51,7 +56,7 @@ jobs:
           gh workflow run cli-weekly-build.yml -f cli_ref=$LATEST
 
           # Create tracking issue
-          cat > issue-body.md << EOF
+          cat > issue-body.md << 'ISSUE_EOF'
           New Docker CLI release detected: **$LATEST**
 
           **Status:** Build automatically triggered
@@ -60,17 +65,21 @@ jobs:
           Expected completion time: ~5-10 minutes
 
           **Monitor build progress:**
-          \`\`\`bash
+          ```bash
           gh run list --workflow=cli-weekly-build.yml --limit 1
           gh run watch
-          \`\`\`
+          ```
 
           **Expected release:** cli-v${LATEST#v}-riscv64
 
           **Upstream release notes:** https://github.com/docker/cli/releases/tag/$LATEST
 
           This issue will track the build progress. Close it once the release is published.
-          EOF
+ISSUE_EOF
+
+          # Substitute variables in issue body
+          sed -i "s/\$LATEST/$LATEST/g" issue-body.md
+          sed -i "s/\${LATEST#v}/${LATEST#v}/g" issue-body.md
 
           gh issue create \
             --title "Building Docker CLI ${LATEST} for RISC-V64" \


### PR DESCRIPTION
## Summary

Implements automatic Docker CLI release tracking (Issue #24).

This PR adds a daily workflow that automatically detects new Docker CLI releases from upstream and triggers builds, following the same pattern as the existing Moby release tracking.

## Changes

### New Workflow: `track-cli-releases.yml`

**Schedule:** Daily at 07:00 UTC (1 hour after Moby tracking)

**Functionality:**
1. Checks for latest Docker CLI release from `docker/cli`
2. Compares with existing releases in our repository (`cli-v*-riscv64` format)
3. If new release found:
   - Triggers `cli-weekly-build.yml` automatically with the new version
   - Creates a tracking issue for monitoring build progress
4. Manual trigger support via `workflow_dispatch`

**Pattern Consistency:**
- Follows same structure as `track-moby-releases.yml`
- Uses same issue labeling pattern (`build-in-progress`, `cli-release`)
- Provides build monitoring instructions in issue body

## Benefits

✅ **Automation**: No manual intervention needed for new CLI releases  
✅ **Consistency**: Same pattern as Docker Engine automation  
✅ **Timeliness**: Users get latest CLI versions automatically  
✅ **Tracking**: Issues created for each automated build  

## Testing

The workflow cannot be tested until merged to main (GitHub limitation). After merge, test with:

```bash
# Manual trigger to test detection logic
gh workflow run track-cli-releases.yml

# Monitor the run
gh run watch

# Verify it creates an issue if new version detected
gh issue list --label cli-release
```

## Next Steps After Merge

1. ✅ Merge PR
2. ⏳ Wait for daily run (07:00 UTC) or trigger manually
3. ⏳ Verify it detects current CLI version and either:
   - Skips if already built
   - Triggers build if new version available
4. ⏳ Verify tracking issue is created when build triggered

## Related

- Closes #24
- Complements PR #17 (Docker CLI build support)
- Similar to `track-moby-releases.yml` (added in earlier PR)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow that checks Docker CLI releases daily (07:00 UTC) and on-demand, triggers riscv64 builds when a new release is found, and opens a tracking issue with status, monitoring commands, and the expected target tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->