### PR TITLE
docs: clarify tini usage - host vs container context

### DIFF
--- a/.github/workflows/tini-weekly-build.yml
+++ b/.github/workflows/tini-weekly-build.yml
@@ -148,10 +148,16 @@ jobs:
 
           ## Usage with Docker
 
+          Once tini is installed on your Fedora/RPM-based RISC-V64 host, Docker can use it with any container:
+
           \`\`\`bash
-          # Use tini as container init process
-          docker run --init alpine sh
+          # Docker uses host's tini to init any container
+          docker run --init fedora:latest sh
+          docker run --init debian:latest sh
+          docker run --init ubuntu:latest sh
           \`\`\`
+
+          **Note:** Tini runs on the host OS (Fedora), not inside the container.
 
           ## Build Details
 


### PR DESCRIPTION
## Summary

Fixes confusing documentation in tini release notes that mixed RPM installation (host OS) with container examples, potentially misleading users about where tini runs.

## Problem

The current release notes show:
1. RPM installation for Fedora (host)
2. Then immediately: `docker run --init alpine sh`

This could make users think:
- Tini is for Alpine Linux ❌
- RPMs work on Alpine ❌
- They need Alpine to use tini ❌

## Solution

**Before:**
```bash
docker run --init alpine sh
```

**After:**
```bash
# Docker uses host's tini to init any container
docker run --init fedora:latest sh
docker run --init debian:latest sh
docker run --init ubuntu:latest sh
```

Plus added explicit note: **"Tini runs on the host OS (Fedora), not inside the container."**

## Changes

- Replace single Alpine example with multiple distro examples
- Add explicit note about host vs container context
- Use RPM-friendly distro names (Fedora, Debian, Ubuntu) instead of Alpine
- Clarify that Docker uses the host's tini for ANY container

## Impact

- Future tini releases will have clearer documentation
- Users won't be confused about Alpine/RPM compatibility
- Better understanding of where tini actually runs

## Related

- Addresses user feedback during tini v0.19.0 release review
- No functional changes, documentation only

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker usage documentation to clarify that tini runs on the host OS, not inside containers
  * Added expanded examples for Fedora, Debian, and Ubuntu demonstrating the `--init` flag usage with Docker

<!-- end of auto-generated comment: release notes by coderabbit.ai -->