### PR TITLE
fix: improve RPM workflow error handling and resolve tini dependency issue

### DIFF
--- a/.github/workflows/build-cli-rpm.yml
+++ b/.github/workflows/build-cli-rpm.yml
@@ -77,6 +77,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+
           # Get release tag
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             RELEASE_TAG="${{ github.event.inputs.release_tag }}"
@@ -87,6 +89,12 @@ jobs:
                           awk '{print $1}')
           fi
 
+          # Validate RELEASE_TAG is not empty
+          if [ -z "$RELEASE_TAG" ]; then
+            echo "Error: No matching CLI release found"
+            exit 1
+          fi
+
           echo "Building package for release: $RELEASE_TAG"
           echo "RELEASE_TAG=$RELEASE_TAG" >> $GITHUB_ENV
 
@@ -94,6 +102,13 @@ jobs:
           cd ~/rpmbuild/SOURCES
           rm -f docker
           gh release download $RELEASE_TAG -p docker --repo gounthar/docker-for-riscv64
+
+          # Validate binary was downloaded
+          if [ ! -f docker ]; then
+            echo "Error: Failed to download docker binary from release $RELEASE_TAG"
+            exit 1
+          fi
+
           chmod +x docker
           ls -lh
 
@@ -105,9 +120,17 @@ jobs:
       - name: Update package version
         if: steps.check_release.outputs.has_new_release == 'true'
         run: |
+          set -euo pipefail
+
           # Extract version from tag (cli-v28.5.1-riscv64 -> 28.5.1)
           VERSION=$(echo $RELEASE_TAG | sed 's/^cli-v//; s/-riscv64$//')
           echo "Package version: $VERSION"
+
+          # Validate VERSION extraction succeeded
+          if [ -z "$VERSION" ] || [ "$VERSION" = "$RELEASE_TAG" ]; then
+            echo "Error: Failed to extract version from tag: $RELEASE_TAG"
+            exit 1
+          fi
 
           # Update spec file
           sed -i "s/^Version:.*/Version:        $VERSION/" ~/rpmbuild/SPECS/docker-cli.spec

--- a/.github/workflows/build-compose-rpm.yml
+++ b/.github/workflows/build-compose-rpm.yml
@@ -77,6 +77,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+
           # Get release tag
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             RELEASE_TAG="${{ github.event.inputs.release_tag }}"
@@ -87,6 +89,12 @@ jobs:
                           awk '{print $1}')
           fi
 
+          # Validate RELEASE_TAG is not empty
+          if [ -z "$RELEASE_TAG" ]; then
+            echo "Error: No matching Compose release found"
+            exit 1
+          fi
+
           echo "Building package for release: $RELEASE_TAG"
           echo "RELEASE_TAG=$RELEASE_TAG" >> $GITHUB_ENV
 
@@ -94,6 +102,13 @@ jobs:
           cd ~/rpmbuild/SOURCES
           rm -f docker-compose
           gh release download $RELEASE_TAG -p docker-compose --repo gounthar/docker-for-riscv64
+
+          # Validate binary was downloaded
+          if [ ! -f docker-compose ]; then
+            echo "Error: Failed to download docker-compose binary from release $RELEASE_TAG"
+            exit 1
+          fi
+
           chmod +x docker-compose
           ls -lh
 

--- a/.github/workflows/build-rpm-package.yml
+++ b/.github/workflows/build-rpm-package.yml
@@ -82,6 +82,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+
           # Get release tag from workflow_run or manual input
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             RELEASE_TAG="${{ github.event.inputs.release_tag }}"
@@ -94,6 +96,12 @@ jobs:
                           awk '{print $1}')
           fi
 
+          # Validate RELEASE_TAG is not empty
+          if [ -z "$RELEASE_TAG" ]; then
+            echo "Error: No matching release found"
+            exit 1
+          fi
+
           echo "Building package for release: $RELEASE_TAG"
           echo "RELEASE_TAG=$RELEASE_TAG" >> $GITHUB_ENV
 
@@ -102,6 +110,10 @@ jobs:
           rm -f dockerd docker-proxy containerd containerd-shim-runc-v2 runc
           for binary in dockerd docker-proxy containerd containerd-shim-runc-v2 runc; do
             gh release download $RELEASE_TAG -p $binary --repo gounthar/docker-for-riscv64
+            if [ ! -f "$binary" ]; then
+              echo "Error: Failed to download $binary from release $RELEASE_TAG"
+              exit 1
+            fi
           done
 
           chmod +x *

--- a/.github/workflows/update-rpm-repo.yml
+++ b/.github/workflows/update-rpm-repo.yml
@@ -42,6 +42,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             RELEASE_TAG="${{ github.event.inputs.release_tag }}"
           else
@@ -70,6 +72,12 @@ jobs:
             fi
           fi
 
+          # Validate RELEASE_TAG is not empty
+          if [ -z "$RELEASE_TAG" ]; then
+            echo "Error: No matching release found with RPM packages"
+            exit 1
+          fi
+
           echo "Adding packages from release: $RELEASE_TAG"
           echo "RELEASE_TAG=$RELEASE_TAG" >> $GITHUB_ENV
 
@@ -77,6 +85,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           cd rpm/fedora/riscv64
 
           # Download all RPM packages
@@ -86,6 +95,12 @@ jobs:
             --repo gounthar/docker-for-riscv64 \
             --clobber
 
+          # Validate RPM packages were downloaded
+          if ! ls *.rpm 1> /dev/null 2>&1; then
+            echo "Error: No RPM packages found in release $RELEASE_TAG"
+            exit 1
+          fi
+
           echo ""
           echo "Downloaded packages:"
           ls -lh *.rpm
@@ -94,14 +109,28 @@ jobs:
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
         run: |
+          set -euo pipefail
+
+          # Validate GPG key is set
+          if [ -z "$GPG_PRIVATE_KEY" ]; then
+            echo "Error: GPG_PRIVATE_KEY secret not set"
+            exit 1
+          fi
+
           # Import GPG key for signing
           echo "$GPG_PRIVATE_KEY" | gpg --batch --import
 
           # Verify key imported
+          if ! gpg --list-secret-keys | grep -q .; then
+            echo "Error: Failed to import GPG key"
+            exit 1
+          fi
+
           gpg --list-secret-keys
 
       - name: Create repository metadata
         run: |
+          set -euo pipefail
           cd rpm/fedora/riscv64
 
           # Create repository metadata
@@ -111,6 +140,12 @@ jobs:
           # Sign repository metadata
           echo "Signing repository metadata..."
           gpg --batch --yes --detach-sign --armor repodata/repomd.xml
+
+          # Validate signature was created
+          if [ ! -f repodata/repomd.xml.asc ]; then
+            echo "Error: Failed to create signature for repomd.xml"
+            exit 1
+          fi
 
           echo ""
           echo "Repository metadata created and signed"

--- a/rpm-docker/moby-engine.spec
+++ b/rpm-docker/moby-engine.spec
@@ -16,7 +16,6 @@ Requires:       containerd >= 1.7.28
 Requires:       runc >= 1.3.0
 Requires:       iptables
 Requires:       systemd
-Requires:       tini
 Requires:       libseccomp
 Requires(post): systemd
 Requires(preun): systemd
@@ -26,6 +25,7 @@ Recommends:     ca-certificates
 Recommends:     git
 Recommends:     xz
 Recommends:     docker-cli
+Recommends:     tini
 
 Conflicts:      docker-ce
 Conflicts:      docker-engine


### PR DESCRIPTION
## Summary

Addresses all issues identified in #27 to improve RPM workflow reliability and fix critical dependency issues.

### Critical Fixes 🔴

✅ **Tini Dependency Resolved** (rpm-docker/moby-engine.spec)
- Changed tini from `Requires` to `Recommends`
- Allows moby-engine installation without tini being available in upstream Fedora repos
- Tini is built separately for RISC-V64 and can be installed from our repository

❓ **RPM Repository File Publication** (update-rpm-repo.yml)
- The workflow already creates and commits `rpm/docker-riscv64.repo`
- Added validation to ensure RPM packages exist before processing
- Repository file should be accessible at documented URL after next workflow run

### Error Handling Improvements 🟢

All RPM workflows now include comprehensive error handling:

**RELEASE_TAG Validation**
- ✅ build-rpm-package.yml
- ✅ build-cli-rpm.yml  
- ✅ build-compose-rpm.yml
- ✅ update-rpm-repo.yml

**VERSION Extraction Validation**
- ✅ build-cli-rpm.yml - validates version parsed from `cli-vX.Y.Z-riscv64` format

**Binary Download Validation**
- ✅ build-rpm-package.yml - validates dockerd, docker-proxy, containerd, containerd-shim-runc-v2, runc
- ✅ build-cli-rpm.yml - validates docker binary
- ✅ build-compose-rpm.yml - validates docker-compose binary

**RPM Package Download Validation**
- ✅ update-rpm-repo.yml - ensures RPM packages exist before adding to repository

**GPG Operation Validation** (update-rpm-repo.yml)
- ✅ Validates GPG_PRIVATE_KEY secret is set
- ✅ Validates GPG key import succeeded  
- ✅ Validates repository metadata signature was created

### Technical Details

All modified workflows now:
- Use `set -euo pipefail` for proper error handling
- Provide clear, actionable error messages when operations fail
- Exit with proper error codes on validation failures
- Validate critical operations before proceeding to next steps

### Changes Made

- `.github/workflows/update-rpm-repo.yml` - Added RELEASE_TAG, RPM download, and GPG validation
- `.github/workflows/build-rpm-package.yml` - Added RELEASE_TAG and binary download validation
- `.github/workflows/build-cli-rpm.yml` - Added RELEASE_TAG, VERSION, and binary download validation
- `.github/workflows/build-compose-rpm.yml` - Added RELEASE_TAG and binary download validation  
- `rpm-docker/moby-engine.spec` - Moved tini from Requires to Recommends

### Testing

✅ All YAML files validated with Python yaml.safe_load()
⏳ Workflows need to be triggered to verify runtime behavior
⏳ RPM repository file availability should be verified after next workflow run

### Follow-up Actions

After merge:
1. Trigger a manual workflow run to verify error handling works correctly
2. Test failure scenarios (e.g., missing release, missing binaries)
3. Verify RPM repository file is accessible at documented URL
4. Update issue #27 with results

Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented comprehensive validation and error handling improvements across deployment workflows to enhance build reliability and provide clearer error messages during package creation and deployment.
  * Modified RPM package dependencies: tini is now recommended rather than strictly required, providing greater flexibility in installation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->