### PR TITLE
feat: optimize workflow runner allocation for better resource utilization

### DIFF
--- a/.github/workflows/build-cli-package.yml
+++ b/.github/workflows/build-cli-package.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build-deb:
-    runs-on: [self-hosted, riscv64]
+    runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
 
     steps:

--- a/.github/workflows/build-cli-rpm.yml
+++ b/.github/workflows/build-cli-rpm.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build-cli-rpm:
-    runs-on: [self-hosted, riscv64]
+    runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
 
     steps:

--- a/.github/workflows/build-compose-package.yml
+++ b/.github/workflows/build-compose-package.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build-deb:
-    runs-on: [self-hosted, riscv64]
+    runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
 
     steps:

--- a/.github/workflows/build-compose-rpm.yml
+++ b/.github/workflows/build-compose-rpm.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build-compose-rpm:
-    runs-on: [self-hosted, riscv64]
+    runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
 
     steps:

--- a/.github/workflows/build-debian-package.yml
+++ b/.github/workflows/build-debian-package.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build-deb:
-    runs-on: [self-hosted, riscv64]
+    runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
 
     steps:

--- a/.github/workflows/build-rpm-package.yml
+++ b/.github/workflows/build-rpm-package.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build-rpm:
-    runs-on: [self-hosted, riscv64]
+    runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
 
     steps:

--- a/.github/workflows/build-tini-rpm.yml
+++ b/.github/workflows/build-tini-rpm.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build-tini-rpm:
-    runs-on: [self-hosted, riscv64]
+    runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
 
     steps:

--- a/.github/workflows/track-cli-releases.yml
+++ b/.github/workflows/track-cli-releases.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   check-release:
-    runs-on: [self-hosted, riscv64]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/track-moby-releases.yml
+++ b/.github/workflows/track-moby-releases.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-release:
-    runs-on: [self-hosted, riscv64]
+    runs-on: ubuntu-latest
     
     steps:
       - name: Checkout repository

--- a/.github/workflows/update-rpm-repo.yml
+++ b/.github/workflows/update-rpm-repo.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   update-repo:
-    runs-on: [self-hosted, riscv64]
+    runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
 
     steps:


### PR DESCRIPTION
## Summary

This PR optimizes runner allocation by migrating non-compilation workflows from the self-hosted RISC-V64 runner to GitHub-hosted `ubuntu-latest` runners. This strategic change improves resource utilization and workflow efficiency.

## Problem

Currently, all workflows use `[self-hosted, riscv64]` runners, but not all workflows actually require native RISC-V64 hardware:
- Package building workflows just download pre-built binaries and create .deb/.rpm packages
- Release tracking workflows only make GitHub API calls
- Repository management workflows run standard Linux tools (reprepro, createrepo_c)

This unnecessarily loads the BananaPi F3 runner and prevents parallel execution of these lightweight tasks.

## Solution

**Workflows migrated to `ubuntu-latest`** (10 workflows):
- `track-moby-releases.yml` - GitHub API calls and issue creation
- `track-cli-releases.yml` - GitHub API calls and issue creation  
- `build-debian-package.yml` - Downloads binaries, creates .deb packages
- `build-compose-package.yml` - Downloads binaries, creates .deb packages
- `build-cli-package.yml` - Downloads binaries, creates .deb packages
- `build-rpm-package.yml` - Downloads binaries, creates .rpm packages
- `build-compose-rpm.yml` - Downloads binaries, creates .rpm packages
- `build-cli-rpm.yml` - Downloads binaries, creates .rpm packages
- `build-tini-rpm.yml` - Downloads binaries, creates .rpm packages
- `update-rpm-repo.yml` - Repository management with createrepo_c

**Workflows remaining on self-hosted runner** (5 workflows):
- `docker-weekly-build.yml` - Compiles Docker Engine from Moby source
- `compose-weekly-build.yml` - Compiles Docker Compose v2
- `cli-weekly-build.yml` - Compiles Docker CLI
- `tini-weekly-build.yml` - Compiles tini binaries
- `track-runner-releases.yml` - Checks local runner version (needs access to runner installation)

## Benefits

1. **Reduced runner load**: BananaPi F3 now only handles compilation tasks
2. **Parallel execution**: Package/repo workflows can run simultaneously on GitHub runners
3. **Faster startup**: No waiting for self-hosted runner availability
4. **Cost efficiency**: Leverages free GitHub Actions minutes for non-specialized tasks
5. **Better reliability**: GitHub-hosted runners have higher availability

## Technical Notes

- Package building tools (dpkg-buildpackage, rpmbuild) support cross-architecture packaging
- These tools work with pre-built RISC-V64 binaries without requiring native hardware
- Repository management tools (reprepro, createrepo_c) are architecture-agnostic
- GitHub API and release management don't require specific hardware

## Testing Plan

1. Monitor next scheduled workflow runs to ensure migrations work correctly
2. Test manual workflow triggers for both tracking and package building workflows
3. Verify package artifacts are created successfully
4. Confirm repository updates function properly

## Documentation

CLAUDE.md has been updated locally (not committed due to .gitignore) with a new "Runner Strategy" section documenting which workflows use which runners and the rationale behind the allocation.

## Impact

- No breaking changes
- All workflows remain functionally identical
- No changes to workflow outputs or artifacts
- Existing release process unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline configuration to standardize execution environments across multiple CI/CD workflows. This improves build consistency and infrastructure management without affecting application functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->