### PR TITLE
fix: prevent APT repo workflow from processing tini releases

### DIFF
--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -40,7 +40,7 @@ jobs:
           else
             # Find the latest -riscv64 release (docker, compose, or cli) using JSON output
             RELEASE_TAG=$(gh release list --repo gounthar/docker-for-riscv64 --limit 50 --json tagName | \
-                          jq -r '.[] | select(.tagName | test("(compose-|cli-)?v[0-9]+\\.[0-9]+\\.[0-9]+-riscv64$")) | .tagName' | \
+                          jq -r '.[] | select(.tagName | test("^(compose-|cli-)?v[0-9]+\\.[0-9]+\\.[0-9]+-riscv64$")) | .tagName' | \
                           head -1)
           fi
 


### PR DESCRIPTION
## Summary

Fixes APT repository workflow failures caused by incorrectly processing tini releases. The workflow now properly filters to only process docker, compose, and cli releases that have .deb packages.

## Problem

The APT repository workflow was failing with:
```
❌ No .deb file found in release tini-v0.19.0-riscv64
```

This happened because tini releases only contain RPM packages (not .deb packages), but the workflow's regex pattern was matching tini releases.

## Root Cause

The regex pattern `(compose-|cli-)?v[0-9]+\.[0-9]+\.[0-9]+-riscv64$` was not anchored to the beginning of the string, so it would match the substring `v0.19.0-riscv64` within `tini-v0.19.0-riscv64`.

## Solution

Added `^` anchor to the beginning of the regex pattern:
```bash
# Before: "(compose-|cli-)?v[0-9]+\\.[0-9]+\\.[0-9]+-riscv64$"
# After:  "^(compose-|cli-)?v[0-9]+\\.[0-9]+\\.[0-9]+-riscv64$"
```

Now the pattern requires the string to start with:
- Nothing (docker releases: `v28.5.1-riscv64`)
- `compose-` prefix (compose releases: `compose-v2.40.1-riscv64`)
- `cli-` prefix (cli releases: `cli-v28.5.1-riscv64`)

And will reject:
- `tini-v0.19.0-riscv64` ❌
- Any other prefixed releases ❌

## Testing

The workflow will now correctly skip tini releases and only process releases with .deb packages available.

## Related Issues

Resolves the workflow failures seen in recent APT repository update runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined release tag validation in automated release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->