### PR TITLE
fix: skip tini release creation if version already exists

### DIFF
--- a/.github/workflows/tini-weekly-build.yml
+++ b/.github/workflows/tini-weekly-build.yml
@@ -180,12 +180,18 @@ jobs:
           Built natively on RISC-V64 hardware (BananaPi F3)
           EOF
 
-          # For development builds, delete existing release if it exists
-          if [[ "$RELEASE_VERSION" =~ -dev$ ]]; then
-            echo "Checking for existing development release..."
-            if gh release view "${RELEASE_VERSION}" >/dev/null 2>&1; then
-              echo "Deleting existing release ${RELEASE_VERSION}..."
+          # Check if release already exists
+          if gh release view "${RELEASE_VERSION}" >/dev/null 2>&1; then
+            if [[ "$RELEASE_VERSION" =~ -dev$ ]]; then
+              # For development builds, delete and recreate
+              echo "Deleting existing development release ${RELEASE_VERSION}..."
               gh release delete "${RELEASE_VERSION}" --yes
+            else
+              # For official releases, skip if already exists
+              echo "✅ Release ${RELEASE_VERSION} already exists, skipping creation"
+              echo "Existing release details:"
+              gh release view "${RELEASE_VERSION}"
+              exit 0
             fi
           fi
 


### PR DESCRIPTION
## Summary

Fixes weekly tini build failures when trying to create a release that already exists for the same upstream version.

## Problem

The Weekly Tini build was failing with:
```
a release with the same tag name already exists: tini-v0.19.0-riscv64
```

This occurred because:
1. Weekly builds default to tini version `v0.19.0`
2. A release for `tini-v0.19.0-riscv64` already exists from a previous successful build
3. The workflow tried to create the same release again, causing a failure

## Root Cause

The workflow only had logic to handle existing development builds (with `-dev` suffix). For official version releases, it would always attempt to create a new release without checking if it already exists.

## Solution

Enhanced the release creation logic to:

1. **Check if release exists** before attempting creation
2. **For official versions** (e.g., `tini-v0.19.0-riscv64`):
   - If release exists: skip creation and exit successfully
   - If release doesn't exist: create new release
3. **For dev builds** (e.g., `tini-v20251026-dev`):
   - If release exists: delete and recreate (as before)
   - If release doesn't exist: create new release

## Benefits

- Weekly scheduled builds can run successfully even when upstream tini hasn't released a new version
- No duplicate release creation attempts
- Graceful handling of already-built versions
- Development builds still get refreshed each time

## Testing

The workflow will now:
- ✅ Skip creating `tini-v0.19.0-riscv64` if it already exists
- ✅ Create a new release if the version doesn't exist yet
- ✅ Still rebuild dev versions each time

## Related Issues

Fixes the tini workflow failures seen in recent scheduled runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release creation workflow handling to better manage existing releases during automated build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->