### PR TITLE
fix: use JSON output for reliable release tag detection in RPM workflow

### DIFF
--- a/.github/workflows/build-rpm-package.yml
+++ b/.github/workflows/build-rpm-package.yml
@@ -35,12 +35,10 @@ jobs:
             exit 0
           fi
 
-          # Find the latest docker release
-          RELEASE_TAG=$(gh release list --repo gounthar/docker-for-riscv64 --limit 10 | \
-                        grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-riscv64' | \
-                        grep -v '^compose-' | grep -v '^cli-' | \
-                        head -1 | \
-                        awk '{print $1}')
+          # Find the latest docker release using JSON output
+          RELEASE_TAG=$(gh release list --repo gounthar/docker-for-riscv64 --limit 50 --json tagName | \
+                        jq -r '.[] | select(.tagName | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-riscv64$")) | .tagName' | \
+                        head -1)
 
           if [ -z "$RELEASE_TAG" ]; then
             echo "No Docker release found - skipping package build"
@@ -88,12 +86,10 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             RELEASE_TAG="${{ github.event.inputs.release_tag }}"
           else
-            # Find the latest docker release created by the workflow
-            RELEASE_TAG=$(gh release list --repo gounthar/docker-for-riscv64 --limit 10 | \
-                          grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-riscv64' | \
-                          grep -v '^compose-' | grep -v '^cli-' | \
-                          head -1 | \
-                          awk '{print $1}')
+            # Find the latest docker release created by the workflow using JSON output
+            RELEASE_TAG=$(gh release list --repo gounthar/docker-for-riscv64 --limit 50 --json tagName | \
+                          jq -r '.[] | select(.tagName | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-riscv64$")) | .tagName' | \
+                          head -1)
           fi
 
           # Validate RELEASE_TAG is not empty


### PR DESCRIPTION
## Summary

Fixes RPM build workflow failures caused by incorrect release tag parsing. The workflow was unable to detect docker releases and would fail with "No Docker release found".

## Problem

The RPM workflow used text-based grep to find docker releases:

```bash
gh release list --repo gounthar/docker-for-riscv64 --limit 10 | \
  grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-riscv64' | \
  grep -v '^compose-' | grep -v '^cli-' | \
  head -1 | \
  awk '{print $1}'
```

**Issue**: The output from `gh release list` looks like this:
```
Docker v28.5.1 for RISC-V64    [TAB]    v28.5.1-riscv64    [TAB]    2025-10-18T14:31:18Z
```

The pattern `^v[0-9]+\.[0-9]+\.[0-9]+-riscv64` was trying to match the **start of the line**, which begins with "Docker", not "v28.5.1-riscv64". This caused:
- ❌ grep found no matches
- ❌ RELEASE_TAG was empty
- ❌ Workflow failed: "No Docker release found - skipping package build"

Additionally, `awk '{print $1}'` would extract the title (first column) instead of the tag (third column).

## Solution

Switched to JSON-based parsing, matching the approach used in the APT repository workflow (PR #39):

```bash
gh release list --repo gounthar/docker-for-riscv64 --limit 50 --json tagName | \
  jq -r '.[] | select(.tagName | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-riscv64$")) | .tagName' | \
  head -1
```

**Benefits**:
- ✅ Directly parses tags from JSON structure
- ✅ Anchored regex ensures exact pattern matching
- ✅ Excludes compose-*, cli-*, tini-*, and dev releases
- ✅ More reliable and maintainable
- ✅ Increased limit to 50 for better coverage

## Changes

1. **Line 38-41**: Fixed release detection in "Check if new release exists" step
2. **Line 89-92**: Fixed release detection in "Download release binaries" step
3. Both locations now use identical JSON-based parsing

## Testing

The workflow will now correctly identify docker releases like:
- ✅ `v28.5.1-riscv64` (matches)
- ✅ `v27.5.1-riscv64` (matches)
- ❌ `compose-v2.40.1-riscv64` (excluded)
- ❌ `cli-v28.5.1-riscv64` (excluded)
- ❌ `tini-v0.19.0-riscv64` (excluded)
- ❌ `v20251026-dev` (excluded)

## Related Issues

Similar to the APT repository fix (PR #39) which had the same text-parsing issue. This PR completes the migration of both workflows to reliable JSON-based release detection.

## Impact

Resolves RPM package build failures and enables automatic RPM package creation when new docker releases are published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build automation workflow to use a standardized JSON-based approach for release tag selection, replacing the previous text-parsing method across all deployment paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->