### PR TITLE
fix: add --target riscv64 to rpmbuild for cross-arch packaging

### DIFF
--- a/.github/workflows/build-rpm-package.yml
+++ b/.github/workflows/build-rpm-package.yml
@@ -145,13 +145,13 @@ jobs:
           cd ~/rpmbuild/SPECS
 
           echo "Building runc..."
-          rpmbuild -bb runc.spec
+          rpmbuild -bb --target riscv64 runc.spec
 
           echo "Building containerd..."
-          rpmbuild -bb containerd.spec
+          rpmbuild -bb --target riscv64 containerd.spec
 
           echo "Building moby-engine..."
-          rpmbuild -bb moby-engine.spec
+          rpmbuild -bb --target riscv64 moby-engine.spec
 
           # List built packages
           echo ""


### PR DESCRIPTION
## Summary

Fixes RPM build workflow failures caused by architecture incompatibility when building riscv64 packages on x86_64 runners.

## Problem

The RPM build workflow runs on `ubuntu-latest` (x86_64 architecture) and tries to build RPM packages for riscv64. All spec files declare `BuildArch: riscv64`, causing rpmbuild to fail with:

```
error: No compatible architectures found for build
```

This happened because:
1. Workflow runs on x86_64 host (ubuntu-latest)
2. Spec files specify `BuildArch: riscv64`
3. rpmbuild rejects cross-architecture builds without explicit target flag
4. Build fails before any packaging happens

## Solution

Add `--target riscv64` flag to all rpmbuild commands to explicitly specify the target architecture for cross-architecture packaging:

```bash
# Before
rpmbuild -bb runc.spec

# After  
rpmbuild -bb --target riscv64 runc.spec
```

This tells rpmbuild to build for riscv64 even when running on a different host architecture.

## Why This Works

The workflow downloads **pre-built binaries** from releases - no compilation happens during the RPM build phase. We're only packaging existing binaries into RPM format, which can be done on any host architecture with the `--target` flag.

## Changes

Updated three rpmbuild commands in the "Build RPM packages" step:
- `rpmbuild -bb --target riscv64 runc.spec`
- `rpmbuild -bb --target riscv64 containerd.spec`
- `rpmbuild -bb --target riscv64 moby-engine.spec`

## Testing

After this fix, the workflow will:
- ✅ Accept riscv64 BuildArch on x86_64 host
- ✅ Package pre-built riscv64 binaries into RPM format
- ✅ Generate riscv64 RPM packages in `~/rpmbuild/RPMS/riscv64/`
- ✅ Upload packages to GitHub releases

## Related

This completes the RPM workflow fixes started in PR #41 (JSON-based release detection). Together, these changes fully restore RPM package build functionality.