### PR TITLE
refactor: use self-hosted riscv64 runner for RPM package builds

### DIFF
--- a/.github/workflows/build-rpm-package.yml
+++ b/.github/workflows/build-rpm-package.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build-rpm:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, riscv64]
     if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
 
     steps:
@@ -74,18 +74,6 @@ jobs:
         if: steps.check_release.outputs.has_new_release == 'true'
         run: |
           rpmdev-setuptree || mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
-
-          # Add riscv64 architecture support to rpm
-          mkdir -p ~/.rpmmacros.d
-          cat > ~/.rpmmacros.d/riscv64 << 'EOF'
-          %_arch riscv64
-          %_target_cpu riscv64
-          %_host_cpu riscv64
-          EOF
-
-          # Also set in global rpmrc
-          echo "arch_canon: riscv64: riscv64 1" | sudo tee -a /usr/lib/rpm/rpmrc
-          echo "buildarchtranslate: riscv64: riscv64" | sudo tee -a /usr/lib/rpm/rpmrc
 
       - name: Download release binaries
         if: steps.check_release.outputs.has_new_release == 'true'
@@ -153,17 +141,17 @@ jobs:
       - name: Build RPM packages
         if: steps.check_release.outputs.has_new_release == 'true'
         run: |
-          # Build each package
+          # Build each package (on native riscv64, no --target needed)
           cd ~/rpmbuild/SPECS
 
           echo "Building runc..."
-          rpmbuild -bb --target riscv64 runc.spec
+          rpmbuild -bb runc.spec
 
           echo "Building containerd..."
-          rpmbuild -bb --target riscv64 containerd.spec
+          rpmbuild -bb containerd.spec
 
           echo "Building moby-engine..."
-          rpmbuild -bb --target riscv64 moby-engine.spec
+          rpmbuild -bb moby-engine.spec
 
           # List built packages
           echo ""


### PR DESCRIPTION
## Summary

Switches RPM package build workflow from ubuntu-latest to self-hosted riscv64 runner, eliminating all cross-architecture complexity.

## Background

After multiple attempts to enable cross-arch RPM builds on ubuntu-latest, we consistently hit issues with Ubuntu's rpm not recognizing riscv64 architecture:

**Attempted fixes:**
- ✅ PR #41: JSON-based release detection (succeeded)
- ❌ PR #42: Added `--target riscv64` flag (failed)
- ❌ PR #43: Configured rpm for riscv64 (failed)

Despite all configuration attempts, Ubuntu's rpm consistently rejected riscv64 with:
```
error: No compatible architectures found for build
```

## Solution

Use the self-hosted riscv64 runner where:
- ✅ rpmbuild works natively without cross-arch flags
- ✅ No architecture configuration needed
- ✅ Simpler workflow with fewer moving parts
- ✅ Fast execution (~2-3 minutes for packaging)
- ✅ Same approach as other native build workflows

## Changes

**Workflow Configuration:**
```yaml
# Before
runs-on: ubuntu-latest

# After
runs-on: [self-hosted, riscv64]
```

**Simplifications:**
- Removed riscv64 architecture configuration steps
- Removed `--target riscv64` flags from rpmbuild commands
- Native rpmbuild automatically detects architecture

## Trade-offs

**Pros:**
- ✅ Reliable native builds
- ✅ Much simpler workflow
- ✅ No cross-arch complications
- ✅ Consistent with build workflows (docker, compose, cli, tini)

**Cons:**
- ⚠️ Uses self-hosted runner slot
- ⚠️ Adds ~2-3 minutes load to runner

**Mitigation:**
RPM builds are quick (just packaging, no compilation) and run infrequently (only when new releases are created).

## Workflow Strategy

After this change, workflow distribution will be:

**Self-hosted riscv64 runner:**
- Weekly builds (docker, compose, cli, tini)
- RPM package builds (new)
- Runner release tracking

**ubuntu-latest:**
- Debian package builds
- Release tracking
- APT/RPM repository updates

This keeps heavy compilation on self-hosted while using GitHub-hosted for lightweight packaging/tracking tasks.

## Testing

After merge, the workflow will:
1. ✅ Run on native riscv64 hardware
2. ✅ Build RPM packages without architecture errors
3. ✅ Sign and upload packages to releases
4. ✅ Trigger RPM repository update

## Related

Supersedes PR #42 and PR #43 which attempted cross-arch builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD build infrastructure for RPM package generation to use a native build environment, streamlining the build process without end-user impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->