### PR TITLE
fix: use JSON output for reliable release detection in RPM repo workflow

### DIFF
--- a/.github/workflows/update-rpm-repo.yml
+++ b/.github/workflows/update-rpm-repo.yml
@@ -47,29 +47,17 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             RELEASE_TAG="${{ github.event.inputs.release_tag }}"
           else
-            # Find the latest release with RPM packages
+            # Find the latest release with RPM packages using JSON output
             # Look for any release (docker, compose, cli, or tini) that has .rpm files
-            RELEASE_TAG=$(gh release list --repo gounthar/docker-for-riscv64 --limit 20 | \
-                          grep -E '^(v[0-9]+\.[0-9]+\.[0-9]+-riscv64|compose-v|cli-v|tini-v)' | \
-                          head -1 | \
-                          awk '{print $1}')
-
-            # Verify the release has RPM packages
-            ASSETS=$(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name' 2>/dev/null || echo "")
-            if ! echo "$ASSETS" | grep -q '\.rpm$'; then
-              echo "Warning: Latest release $RELEASE_TAG has no RPM packages"
-              echo "Searching for a release with RPM packages..."
-              # Find first release with RPM packages
-              for tag in $(gh release list --repo gounthar/docker-for-riscv64 --limit 20 | \
-                           grep -E '^(v[0-9]+\.[0-9]+\.[0-9]+-riscv64|compose-v|cli-v|tini-v)' | \
-                           awk '{print $1}'); do
-                ASSETS=$(gh release view "$tag" --json assets --jq '.assets[].name' 2>/dev/null || echo "")
-                if echo "$ASSETS" | grep -q '\.rpm$'; then
-                  RELEASE_TAG="$tag"
-                  break
-                fi
-              done
-            fi
+            for tag in $(gh release list --repo gounthar/docker-for-riscv64 --limit 50 --json tagName | \
+                         jq -r '.[] | select(.tagName | test("^(v[0-9]+\\.[0-9]+\\.[0-9]+-riscv64|compose-v|cli-v|tini-v)")) | .tagName'); do
+              ASSETS=$(gh release view "$tag" --json assets --jq '.assets[].name' 2>/dev/null || echo "")
+              if echo "$ASSETS" | grep -q '\.rpm$'; then
+                RELEASE_TAG="$tag"
+                echo "Found release with RPM packages: $RELEASE_TAG"
+                break
+              fi
+            done
           fi
 
           # Validate RELEASE_TAG is not empty


### PR DESCRIPTION
## Summary

Fixes RPM repository workflow failures caused by the same text-parsing bug that affected the RPM build workflow (PR #41).

## Problem

The RPM repository workflow failed with:
```
Error: No matching release found with RPM packages
```

Same root cause as PR #41: text-based grep doesn't work with `gh release list` output format:
```
Docker v28.5.1 for RISC-V64    [TAB]    v28.5.1-riscv64    [TAB]    2025-10-18T14:31:18Z
```

The pattern `^(v[0-9]+\.[0-9]+\.[0-9]+-riscv64|...)` tried to match at the start of the line, but lines start with "Docker", not the tag.

## Solution

Use JSON-based parsing (same approach as PR #41 for RPM build and PR #39 for APT repo):

```bash
# Before: text parsing with grep/awk
gh release list | grep -E '^(v[0-9]+...)' | awk '{print $1}'

# After: JSON parsing with jq
gh release list --json tagName | jq -r '.[] | select(.tagName | test("^...")) | .tagName'
```

**Logic:**
1. Get all release tags via JSON
2. Filter tags matching docker/compose/cli/tini patterns
3. For each tag, check if it has .rpm assets
4. Use first tag with RPM packages

## Changes

- Replaced grep/awk text parsing with jq JSON filtering
- Simplified control flow (single loop instead of nested checks)
- Increased limit from 20 to 50 releases for better coverage

## Testing

After this fix, the workflow will:
- ✅ Correctly find releases with RPM packages
- ✅ Work with any release type (docker, compose, cli, tini)
- ✅ Update RPM repository reliably

## Related

This completes the JSON-based parsing migration:
- ✅ PR #39: APT repository workflow  
- ✅ PR #41: RPM build workflow
- ✅ PR #45 (this): RPM repository workflow

All three workflows now use reliable JSON parsing instead of fragile text parsing.