### PR TITLE
fix: add explicit --repo flag to gh issue create in Track Runner Releases

### DIFF
--- a/.github/workflows/track-runner-releases.yml
+++ b/.github/workflows/track-runner-releases.yml
@@ -1,6 +1,6 @@
 name: Track Runner Releases
 
-on:
+'on':
   schedule:
     # Check for new releases daily at 07:00 UTC
     - cron: '0 7 * * *'
@@ -62,6 +62,7 @@ jobs:
           EOF
 
           gh issue create \
+            --repo gounthar/docker-for-riscv64 \
             --title "Update github-act-runner to $LATEST" \
             --body-file issue-body.md \
             --label "maintenance,runner-update"


### PR DESCRIPTION
## Summary

Fixes the Track Runner Releases workflow failure by adding an explicit `--repo` flag to the `gh issue create` command.

## Problem

The workflow was failing with:
```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

Despite all steps showing as "passed" individually, the job was marked as failed.

## Root Cause

The workflow doesn't checkout the repository code, so when `gh issue create` runs, it attempts to auto-detect the repository context from git but fails because there's no `.git` directory in the working directory.

## Solution

Added explicit `--repo gounthar/docker-for-riscv64` flag to the `gh issue create` command:

```yaml
gh issue create \
  --repo gounthar/docker-for-riscv64 \
  --title "Update github-act-runner to $LATEST" \
  --body-file issue-body.md \
  --label "maintenance,runner-update"
```

This explicitly tells gh which repository to create the issue in, eliminating the need for git repository auto-detection.

## Additional Changes

- Fixed yamllint truthy warning by quoting `'on':`

## Testing

After merge, can be tested by:
1. Manually triggering the "Track Runner Releases" workflow
2. Verifying it completes successfully
3. Checking that an issue is created if runner versions differ

## Changes

- `.github/workflows/track-runner-releases.yml`:
  - Line 3: Changed `on:` to `'on':` (yamllint truthy fix)
  - Line 65: Added `--repo gounthar/docker-for-riscv64` flag

## Related

- Fixes #50
- Failed runs:
  - https://github.com/gounthar/docker-for-riscv64/actions/runs/18833096731
  - https://github.com/gounthar/docker-for-riscv64/actions/runs/18834835444