### PR TITLE
fix: add missing RELEASE_TAG to Upload packages to release step

### DIFF
--- a/.github/workflows/build-rpm-package.yml
+++ b/.github/workflows/build-rpm-package.yml
@@ -201,6 +201,7 @@ jobs:
         if: steps.release.outputs.has-new-release == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.release-tag }}
         run: |
           echo "Uploading packages to release $RELEASE_TAG"
           echo ""


### PR DESCRIPTION
## Summary

Fixes another instance of missing RELEASE_TAG environment variable in the Build RPM Package workflow, this time in the "Upload packages to release" step.

## Problem

The workflow was failing at the upload step with:
```
requires at least 2 arg(s), only received 1
```

When trying to run:
```bash
gh release upload $RELEASE_TAG "$rpm" --repo gounthar/docker-for-riscv64 --clobber
```

## Root Cause

The "Upload packages to release" step uses `$RELEASE_TAG` but didn't have it defined in the environment, causing the variable to be empty and `gh release upload` to fail due to missing arguments.

## Solution

Added the missing environment variable:
```yaml
- name: Upload packages to release
  if: steps.release.outputs.has-new-release == 'true'
  env:
    GH_TOKEN: ${{ github.token }}
    RELEASE_TAG: ${{ steps.release.outputs.release-tag }}  # Added this line
  run: |
    echo "Uploading packages to release $RELEASE_TAG"
```

## Related

- Related to #49 (same type of issue, different step)
- Failed run: https://github.com/gounthar/docker-for-riscv64/actions/runs/18835268953

## Changes

- `.github/workflows/build-rpm-package.yml` (line 204): Added `RELEASE_TAG` to env section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to use an environment variable for improved clarity and consistency in the package upload process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->