### PR TITLE
fix: add error handling for git fetch in retry loop

### DIFF
--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -167,8 +167,12 @@ jobs:
               if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
                 echo "⚠️  Push failed (attempt $RETRY_COUNT/$MAX_RETRIES). Pulling and retrying..."
 
-                # Fetch latest changes
-                git fetch origin apt-repo
+                # Fetch latest changes with error handling
+                if ! git fetch origin apt-repo; then
+                  echo "❌ Failed to fetch from remote. This may indicate network or authentication issues."
+                  echo "Skipping remaining retries and failing the workflow."
+                  exit 1
+                fi
 
                 # Try to rebase our changes on top of remote
                 if git rebase origin/apt-repo; then


### PR DESCRIPTION
## Problem

As identified by @coderabbitai in PR #56, the retry logic was missing error handling for `git fetch origin apt-repo`.

If the fetch fails due to:
- Network connectivity issues
- Authentication problems
- Repository access issues

The workflow would incorrectly proceed to the rebase step, which would then fail for the wrong reason, routing execution into the conflict resolution path and masking the real error.

## Solution

Added explicit error handling for `git fetch`:

```bash
if ! git fetch origin apt-repo; then
  echo "❌ Failed to fetch from remote. This may indicate network or authentication issues."
  echo "Skipping remaining retries and failing the workflow."
  exit 1
fi
```

### Benefits

1. **Clear error messages** - Users immediately know the fetch failed
2. **Fails fast** - No wasted retry attempts when the real issue is connectivity/auth
3. **Better troubleshooting** - Error isn't masked by subsequent rebase failures
4. **Proper exit code** - Workflow fails with exit 1 instead of misleading rebase errors

## Testing

The fix handles these scenarios:

- ✅ Network connectivity issues → Immediate failure with clear message
- ✅ Authentication failures → Immediate failure with clear message
- ✅ Successful fetch → Proceeds normally to rebase logic
- ✅ Rebase conflicts → Still handled by existing conflict resolution

## Changes

- Modified `.github/workflows/update-apt-repo.yml`:
  - Added error check after `git fetch origin apt-repo`
  - Added descriptive error messages
  - Exits immediately on fetch failure

## Related

- Closes #57
- Follow-up to PR #56
- Identified by @coderabbitai review comment