### PR TITLE
docs: complete automated builds and release naming sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,8 @@ docker --version
 - **Docker Engine releases**: `vX.Y.Z-riscv64` (e.g., `v27.5.1-riscv64`)
 - **Docker CLI releases**: `cli-vX.Y.Z-riscv64` (e.g., `cli-v28.5.1-riscv64`)
 - **Docker Compose releases**: `compose-vX.Y.Z-riscv64` (e.g., `compose-v2.40.1-riscv64`)
-- **Development builds**: `vYYYYMMDD-dev`, `cli-vYYYYMMDD-dev`, or `compose-vYYYYMMDD-dev`
+- **Tini releases**: `tini-vX.Y.Z-riscv64` (e.g., `tini-v0.19.0-riscv64`)
+- **Development builds**: `vYYYYMMDD-dev`, `cli-vYYYYMMDD-dev`, `compose-vYYYYMMDD-dev`, or `tini-vYYYYMMDD-dev`
 
 ### Automated Builds
 
@@ -516,10 +517,15 @@ docker --version
 
 **Docker CLI:**
 - Weekly builds: Every Sunday at 04:00 UTC (latest CLI master)
+- Release tracking: Daily check for new official CLI releases
 - Manual trigger support for specific versions
 
 **Docker Compose:**
 - Weekly builds: Every Sunday at 03:00 UTC (latest Compose main)
+- Manual trigger support for specific versions
+
+**Tini:**
+- Weekly builds: Every Sunday at 05:00 UTC (latest Tini master)
 - Manual trigger support for specific versions
 
 ### Components


### PR DESCRIPTION
## Summary

Completes the documentation by adding missing information about Tini automated builds and CLI release tracking.

## Changes

- **Tini automated builds**: Added weekly build schedule (Sunday 05:00 UTC)
- **Docker CLI release tracking**: Added daily release tracking (07:00 UTC)
- **Tini release naming**: Added pattern  (e.g., )
- **Development builds**: Updated to include  pattern

## Context

During documentation review with `/init`, discovered that:
1. Tini component was missing from automated builds section
2. Docker CLI release tracking wasn't documented (workflow exists at 07:00 UTC)
3. Tini release naming pattern was not documented

All four main components (Engine, CLI, Compose, Tini) are now consistently documented.

## Testing

- ✅ Verified schedules match actual workflow files
- ✅ Verified release naming patterns match existing releases
- ✅ Cross-referenced with CLAUDE.md for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Tini release versioning scheme (tini-vX.Y.Z-riscv64) to release naming conventions
  * Extended documentation to include Tini development builds (tini-vYYYYMMDD-dev)
  * Added Tini component information covering weekly automated builds, release artifacts, and deployment details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->