### PR TITLE
fix(workflows): add architecture flag to CLI package build

### DIFF
--- a/.github/workflows/build-cli-package.yml
+++ b/.github/workflows/build-cli-package.yml
@@ -143,7 +143,8 @@ jobs:
         run: |
           # Build package (debian/ already created in previous step)
           # Use -d to skip build dependency checks (we're packaging prebuilt binaries)
-          dpkg-buildpackage -us -uc -b -d
+          # Use -a riscv64 to specify target architecture (building on amd64 host)
+          dpkg-buildpackage -us -uc -b -d -a riscv64
 
           ls -lh ../*.deb
 


### PR DESCRIPTION
## Problem

After merging PR #75, the Debian package build for `cli-v28.5.2-riscv64` is still failing with:

```
dpkg-genbuildinfo: error: binary build with no binary artifacts found; .buildinfo is meaningless
dpkg-buildpackage: error: dpkg-genbuildinfo --build=binary subprocess returned exit status 25
```

**Root cause**: Building riscv64 package on amd64 host without specifying target architecture. The `debian/control` file specifies `Architecture: riscv64`, but `dpkg-buildpackage` defaults to the host architecture (amd64), causing a mismatch.

## Fix

Add `-a riscv64` flag to `dpkg-buildpackage` command in `.github/workflows/build-cli-package.yml`:

```yaml
dpkg-buildpackage -us -uc -b -d -a riscv64
```

This explicitly tells dpkg-buildpackage to build for the riscv64 architecture even when running on an amd64 host.

## Testing

After merge, will re-trigger build for `cli-v28.5.2-riscv64` to verify packages are created successfully.

## Related

- Fixes remaining issue from PR #75
- Release: https://github.com/gounthar/docker-for-riscv64/releases/tag/cli-v28.5.2-riscv64
- Failed build: https://github.com/gounthar/docker-for-riscv64/actions/runs/19133605514