### PR TITLE
fix(debian): skip all cross-compilation debhelper tools

### DIFF
--- a/debian-cli/rules
+++ b/debian-cli/rules
@@ -19,3 +19,9 @@ override_dh_strip:
 
 override_dh_dwz:
 	# Skip dwz for Go binaries
+
+override_dh_makeshlibs:
+	# Skip makeshlibs for prebuilt binary (no cross-compilation toolchain)
+
+override_dh_shlibdeps:
+	# Skip shlibdeps for prebuilt binary (no cross-compilation toolchain)


### PR DESCRIPTION
## Problem

After PR #77, CLI Debian build still fails with:
```
Can't exec "riscv64-linux-gnu-objdump": No such file or directory
dh_makeshlibs: error: riscv64-linux-gnu-objdump returned exit code 25
```

## Root Cause

`dh_makeshlibs` and `dh_shlibdeps` also require cross-compilation toolchain tools that aren't available on amd64 host.

## Fix

Add overrides to skip both:
- `dh_makeshlibs` - generates shared library metadata  
- `dh_shlibdeps` - calculates shared library dependencies

Since we're packaging a prebuilt static binary, neither of these steps are needed.

## Testing

After merge, will re-trigger CLI package builds.

## Related

- Follows PR #77
- Release: https://github.com/gounthar/docker-for-riscv64/releases/tag/cli-v28.5.2-riscv64
- Failed build: https://github.com/gounthar/docker-for-riscv64/actions/runs/19133934138