### PR TITLE
fix(engine): complete Debian packaging for cross-architecture build

### DIFF
--- a/.github/workflows/build-debian-package.yml
+++ b/.github/workflows/build-debian-package.yml
@@ -89,6 +89,13 @@ jobs:
           chmod +x *
           ls -lh
 
+      - name: Prepare Debian packaging
+        if: steps.check_release.outputs.has_new_release == 'true'
+        run: |
+          # Copy debian packaging files from debian-docker to debian
+          cp -r debian-docker debian
+          echo "Debian packaging prepared"
+
       - name: Update package version in changelog
         if: steps.check_release.outputs.has_new_release == 'true'
         run: |
@@ -122,7 +129,9 @@ jobs:
       - name: Build package
         if: steps.check_release.outputs.has_new_release == 'true'
         run: |
-          dpkg-buildpackage -us -uc -b
+          # Use -d to skip build dependency checks (we're packaging prebuilt binaries)
+          # Use -a riscv64 to specify target architecture (building on amd64 host)
+          dpkg-buildpackage -us -uc -b -d -a riscv64
 
       - name: Run lintian checks
         if: steps.check_release.outputs.has_new_release == 'true'

--- a/debian-docker/rules
+++ b/debian-docker/rules
@@ -15,10 +15,13 @@ override_dh_auto_install:
 	install -D -m 0644 debian-docker/docker.socket debian/docker.io/usr/lib/systemd/system/docker.socket
 
 override_dh_shlibdeps:
-	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
+	# Skip shlibdeps for prebuilt binary (no cross-compilation toolchain)
 
 override_dh_strip:
-	dh_strip --no-automatic-dbgsym
+	# Skip strip for prebuilt binary (no cross-compilation toolchain)
 
 override_dh_dwz:
 	# Skip dwz (Go binaries, no debug symbols)
+
+override_dh_makeshlibs:
+	# Skip makeshlibs for prebuilt binary (no cross-compilation toolchain)


### PR DESCRIPTION
## Problem

Docker Engine Debian package build failed with:
```
dpkg-buildpackage: error: cannot open file debian/changelog: No such file or directory
```

## Root Causes

1. **Missing preparation step**: Workflow doesn't copy `debian-docker/` to `debian/` before building
2. **Cross-compilation tools**: Same issues as CLI package - missing riscv64-linux-gnu-* tools
3. **Missing architecture flags**: No `-d` and `-a riscv64` flags on dpkg-buildpackage

## Fixes

### 1. Add Debian packaging preparation step

Copy `debian-docker/` directory to `debian/` before building.

### 2. Skip cross-compilation debhelper tools

`debian-docker/rules`:
```makefile
override_dh_strip:
	# Skip strip for prebuilt binary (no cross-compilation toolchain)

override_dh_shlibdeps:
	# Skip shlibdeps for prebuilt binary (no cross-compilation toolchain)

override_dh_makeshlibs:
	# Skip makeshlibs for prebuilt binary (no cross-compilation toolchain)
```

### 3. Add architecture and dependency flags

`.github/workflows/build-debian-package.yml`:
```diff
- dpkg-buildpackage -us -uc -b
+ dpkg-buildpackage -us -uc -b -d -a riscv64
```

## Testing

After merge, will re-trigger Engine package build for `v28.5.2-riscv64`.

## Related

- Follows PR #78 (CLI package fixes)
- Release: https://github.com/gounthar/docker-for-riscv64/releases/tag/v28.5.2-riscv64  
- Failed build: https://github.com/gounthar/docker-for-riscv64/actions/runs/19133982515