### PR TITLE
fix(engine): auto-update Debian changelog version

### DIFF
--- a/.github/workflows/build-debian-package.yml
+++ b/.github/workflows/build-debian-package.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.check_release.outputs.has_new_release == 'true'
         run: |
           sudo apt-get update
-          sudo apt-get install -y debhelper dh-make dpkg-dev lintian
+          sudo apt-get install -y debhelper dh-make dpkg-dev lintian devscripts libdistro-info-perl
 
       - name: Download release binaries
         if: steps.check_release.outputs.has_new_release == 'true'
@@ -117,10 +117,22 @@ jobs:
           MOBY_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
           cd ..
 
+          # Set DEBEMAIL to avoid interactive prompt
+          export DEBEMAIL="github-actions[bot]@users.noreply.github.com"
+          export DEBFULLNAME="GitHub Actions"
+
           # Check if this version is already in changelog
           if ! head -1 debian/changelog | grep -q "$VERSION"; then
-            echo "Version $VERSION not in changelog, needs update"
-            # In production, use dch to add entry, but changelog should be pre-updated
+            echo "Version $VERSION not in changelog, updating..."
+            cd debian
+            dch --newversion "${VERSION}-1" \
+                --distribution trixie \
+                --force-distribution \
+                --check-dirname-level 0 \
+                "RISC-V64 prebuilt Docker Engine ${VERSION} from upstream moby/moby commit ${MOBY_COMMIT}"
+            cd ..
+          else
+            echo "Version $VERSION already in changelog"
           fi
 
           echo "Package version: $VERSION"


### PR DESCRIPTION
## Problem

The Engine Debian package build is using the wrong version number. For example, when building `v28.5.2-riscv64`, the package is named `docker.io_28.5.1-3_riscv64.deb` instead of `docker.io_28.5.2-1_riscv64.deb`.

## Root Cause

The workflow step "Update package version in changelog" was only **checking** if the version existed but not actually **updating** it. The code had a comment "In production, use dch to add entry" but never implemented it.

## Fix

1. **Add required dependencies**: `devscripts` (provides dch) and `libdistro-info-perl`

2. **Implement automatic version update**:
   ```bash
   dch --newversion "${VERSION}-1" \
       --distribution trixie \
       --force-distribution \
       --check-dirname-level 0 \
       "RISC-V64 prebuilt Docker Engine ${VERSION} from upstream moby/moby commit ${MOBY_COMMIT}"
   ```

3. **Set environment variables** to avoid interactive prompts

## Testing

After merge, will re-trigger Engine Debian package build for `v28.5.2-riscv64` to verify it creates `docker.io_28.5.2-1_riscv64.deb`.

## Related

- Current package: `docker.io_28.5.1-3_riscv64.deb` (wrong version)
- Expected package: `docker.io_28.5.2-1_riscv64.deb`
- Release: https://github.com/gounthar/docker-for-riscv64/releases/tag/v28.5.2-riscv64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Debian package build automation with additional dependencies and improved changelog management workflow to streamline the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->