### PR TITLE
fix(cli-rpm): use native RISC-V64 runner for RPM builds

### DIFF
--- a/.github/workflows/build-cli-rpm.yml
+++ b/.github/workflows/build-cli-rpm.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build-cli-rpm:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, riscv64]
     if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
 
     steps:
@@ -99,8 +99,8 @@ jobs:
         if: steps.release.outputs.has-new-release == 'true'
         run: |
           cd ~/rpmbuild/SPECS
-          # Use --target riscv64 when building on amd64 host
-          rpmbuild -bb --target riscv64 docker-cli.spec
+          # Building on native riscv64, no --target needed
+          rpmbuild -bb docker-cli.spec
 
           echo ""
           echo "Built RPM package:"


### PR DESCRIPTION
## Problem

CLI RPM builds have been **failing** with:
```
error: No compatible architectures found for build
```

This is why there's no `docker-cli-28.5.2-1.riscv64.rpm` in the release, only the old `docker-cli-28.5.1-1.riscv64.rpm`.

## Root Cause

The CLI RPM workflow was using `runs-on: ubuntu-latest` (amd64) and trying to use `--target riscv64`. However, RPM packages with `BuildArch: riscv64` in the spec file **cannot be built on different architectures**, even with `--target`.

This differs from Debian which supports cross-building with the `-a riscv64` flag.

## Fix

Change to use native RISC-V64 hardware, matching the Engine RPM workflow:

1. **Change runner**: `ubuntu-latest` → `[self-hosted, riscv64]`
2. **Remove flag**: `--target riscv64` (not needed on native hardware)

This matches `build-rpm-package.yml` which successfully builds Engine RPM packages.

## Testing

After merge, will trigger CLI RPM build for `cli-v28.5.2-riscv64` to create the missing package.

## Related

- Missing package: `docker-cli-28.5.2-1.riscv64.rpm`
- All previous builds failed: #19134107847, #19134038270, #19133934407
- Release: https://github.com/gounthar/docker-for-riscv64/releases/tag/cli-v28.5.2-riscv64