### PR TITLE
fix: ensure all packages preserved in APT repository updates

### DIFF
--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -86,7 +86,8 @@ jobs:
           # Find latest Compose release
           COMPOSE_RELEASE=$(gh release list --repo gounthar/docker-for-riscv64 \
                             --limit 50 --json tagName | \
-                            jq -r '.[] | select(.tagName | test("^compose-v[0-9]+\\.[0-9]+\\.[0-9]+-riscv64$")) | .tagName' | \
+                            jq -r '.[] | select(.tagName | test("^compose-v[0-9]+\\.[0-9]+\\.[0-9]+-riscv64$")) | \
+                            .tagName' | \
                             head -1)
           echo "Latest Compose release: $COMPOSE_RELEASE"
           echo ""
@@ -231,17 +232,20 @@ jobs:
 
           git add dists pool
 
+
           # Create commit message with all package versions
-          COMMIT_MSG="Update APT repository with latest packages
-
-Triggered by: $PACKAGE_NAME $VERSION (release $RELEASE_TAG)
-
-All packages updated:
-$(reprepro -b . list trixie | sed 's/^/  - /')
-
-Automated update from GitHub Actions.
-Workflow: ${{ github.workflow }}
-Run: ${{ github.run_id }}"
+          # Capture package list with error handling
+          PACKAGE_LIST=$(reprepro -b . list trixie | sed 's/^/  - /' || echo "  - Failed to list packages")
+          
+          # Build commit message using printf (YAML-safe)
+          COMMIT_MSG=$(printf "%s\n\n%s\n\n%s\n%s\n\n%s\n%s\n%s" \
+            "Update APT repository with latest packages" \
+            "Triggered by: $PACKAGE_NAME $VERSION (release $RELEASE_TAG)" \
+            "All packages updated:" \
+            "$PACKAGE_LIST" \
+            "Automated update from GitHub Actions." \
+            "Workflow: ${{ github.workflow }}" \
+            "Run: ${{ github.run_id }}")
 
           git commit -m "$COMMIT_MSG"
 


### PR DESCRIPTION
## Problem

The APT repository workflow was failing to preserve all packages when updating individual packages (issue #82). Each update would cause some packages to disappear from the repository index, creating a frustrating flip-flop situation for users.

**Symptoms:**
- Update docker.io → docker-cli disappears
- Update docker-cli → docker.io reverts to old version
- containerd and runc remained stable

## Root Causes

1. **Single-package downloads**: Workflow only downloaded the package that triggered it
2. **Multiple versions in releases**: Some releases had multiple .deb versions (e.g., 28.5.1-3 and 28.5.2-1)
3. **No verification**: No check to ensure all packages remained present

## Solution

Completely redesigned the download and update logic:

### 1. Download ALL Packages
```yaml
# Always download latest from all release types:
- docker.io, containerd, runc from Engine release (v*)
- docker-cli from CLI release (cli-v*)  
- docker-compose-plugin from Compose release (compose-v*)
```

### 2. Clean Duplicates
Keep only the newest version of each package before adding to reprepro:
```bash
for pattern in docker.io docker-cli docker-compose-plugin containerd runc; do
  ls -t ${pattern}_*.deb 2>/dev/null | tail -n +2 | xargs -r rm -v
done
```

### 3. Verify Completeness
Added verification step that **fails the workflow** if any expected package is missing:
```yaml
EXPECTED_PACKAGES=(containerd docker-cli docker.io runc)
# Check each one, fail if any missing
```

### 4. Better Commit Messages
Show all packages in repository, not just the one that triggered:
```
Update APT repository with latest packages

Triggered by: docker-cli 28.5.2 (release cli-v28.5.2-riscv64)

All packages updated:
  - containerd 1.7.28-1
  - docker-cli 28.5.2-riscv64-1
  - docker.io 28.5.2-1
  - runc 1.3.0-1
```

## Benefits

✅ All packages always present in APT repository  
✅ Users can reliably install/upgrade all components via APT  
✅ Automated verification catches issues immediately  
✅ Single source of truth: always use latest from each release type  
✅ No more flip-flopping between package versions  

## Testing Plan

After merge:

1. **Manual trigger**: Run workflow and verify all packages present
   ```bash
   gh workflow run update-apt-repo.yml -f release_tag=cli-v28.5.2-riscv64
   ```

2. **Check repository**: Verify all packages are indexed
   ```bash
   curl -s https://gounthar.github.io/docker-for-riscv64/dists/trixie/main/binary-riscv64/Packages | grep "^Package:"
   ```
   Should show: containerd, docker-cli, docker.io, runc

3. **Test user upgrade**: Verify users can upgrade
   ```bash
   sudo apt-get update
   sudo apt list --upgradable | grep docker
   ```

4. **Subsequent updates**: Trigger another update and verify packages don't disappear

## Changes

- **Modified**: `.github/workflows/update-apt-repo.yml`
  - Rewritten download logic (62 lines → 121 lines)
  - Added package verification step
  - Improved commit messages
  - Better logging and error messages

## Related

- Fixes #82
- Follow-up to PRs #75-#81 (package build fixes)

## Review Notes

This is a significant architectural change to the APT workflow. The key insight is that we need to treat the APT repository as containing the **union** of all latest packages, not just individually updating one package at a time.

---

Ready for review and testing!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Unified package update process to fetch and publish multiple package types (Engine, CLI, Compose) per run.
  * Verifies all expected packages are present and fails when packages are missing.
  * Produces richer, multi-line commit messages listing updated package versions.
  * Improves reliability with enhanced retry and conflict-recovery handling and clearer post-publish reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->