### PR TITLE
fix: set maintainer label in Dockerfile.riscv64

### DIFF
--- a/Dockerfile.riscv64
+++ b/Dockerfile.riscv64
@@ -3,7 +3,7 @@
 # TODO: Update with actual riscv64 build steps and base image.
 
 FROM scratch
-LABEL maintainer="TODO: set maintainer"
+LABEL maintainer="Bruno Verachten <gounthar@gmail.com>"
 LABEL architecture="riscv64"
 
 # Stub command


### PR DESCRIPTION
Replace TODO placeholder with actual maintainer information (Bruno Verachten <gounthar@gmail.com>).