### PR TITLE
fix: clean rpmbuild directory before building to prevent old RPM uploads

### DIFF
--- a/.github/workflows/build-cli-rpm.yml
+++ b/.github/workflows/build-cli-rpm.yml
@@ -45,6 +45,13 @@ jobs:
         run: |
           rpmdev-setuptree || mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
+      - name: Clean previous RPM builds
+        if: steps.release.outputs.has-new-release == 'true'
+        run: |
+          # Remove any existing RPM files to prevent uploading old versions
+          rm -f ~/rpmbuild/RPMS/riscv64/docker-cli-*.rpm
+          echo "Cleaned previous docker-cli RPM files"
+
       - name: Download docker CLI binary
         if: steps.release.outputs.has-new-release == 'true'
         env:

--- a/.github/workflows/build-compose-rpm.yml
+++ b/.github/workflows/build-compose-rpm.yml
@@ -45,6 +45,13 @@ jobs:
         run: |
           rpmdev-setuptree || mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
+      - name: Clean previous RPM builds
+        if: steps.release.outputs.has-new-release == 'true'
+        run: |
+          # Remove any existing RPM files to prevent uploading old versions
+          rm -f ~/rpmbuild/RPMS/riscv64/docker-compose-plugin-*.rpm
+          echo "Cleaned previous docker-compose-plugin RPM files"
+
       - name: Download compose binary
         if: steps.release.outputs.has-new-release == 'true'
         env:

--- a/.github/workflows/build-rpm-package.yml
+++ b/.github/workflows/build-rpm-package.yml
@@ -49,6 +49,15 @@ jobs:
         run: |
           rpmdev-setuptree || mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
+      - name: Clean previous RPM builds
+        if: steps.release.outputs.has-new-release == 'true'
+        run: |
+          # Remove any existing RPM files to prevent uploading old versions
+          rm -f ~/rpmbuild/RPMS/riscv64/moby-engine-*.rpm
+          rm -f ~/rpmbuild/RPMS/riscv64/containerd-*.rpm
+          rm -f ~/rpmbuild/RPMS/riscv64/runc-*.rpm
+          echo "Cleaned previous Engine RPM files"
+
       - name: Download release binaries
         if: steps.release.outputs.has-new-release == 'true'
         env:

--- a/.github/workflows/build-tini-rpm.yml
+++ b/.github/workflows/build-tini-rpm.yml
@@ -60,6 +60,14 @@ jobs:
         run: |
           rpmdev-setuptree || mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
+      - name: Clean previous RPM builds
+        if: steps.release.outputs.has-new-release == 'true'
+        run: |
+          # Remove any existing RPM files to prevent uploading old versions
+          rm -f ~/rpmbuild/RPMS/riscv64/tini-*.rpm
+          rm -f ~/rpmbuild/RPMS/riscv64/tini-static-*.rpm
+          echo "Cleaned previous tini RPM files"
+
       - name: Download tini binaries
         if: steps.release.outputs.has-new-release == 'true'
         env:


### PR DESCRIPTION
## Problem

Releases contain multiple versions of the same RPM package:

**v28.5.2-riscv64 release:**
- ❌ `moby-engine-28.5.1-1.riscv64.rpm` (old)
- ✅ `moby-engine-28.5.2-1.riscv64.rpm` (new)
- ❌ `docker.io_28.5.1-3_riscv64.deb` (old)  
- ✅ `docker.io_28.5.2-1_riscv64.deb` (new)

**cli-v28.5.2-riscv64 release:**
- ❌ `docker-cli-28.5.1-1.riscv64.rpm` (old)
- ✅ `docker-cli-28.5.2-1.riscv64.rpm` (new)

## Root Cause

The RPM build workflows run on the **self-hosted riscv64 runner**, which persists state between builds. Old RPM files remain in `~/rpmbuild/RPMS/riscv64/` and get re-uploaded because the upload step uses wildcards:

```bash
for rpm in ~/rpmbuild/RPMS/riscv64/docker-cli-*.rpm; do
  gh release upload "$RELEASE_TAG" "$rpm" --clobber
done
```

This matches ALL files, including leftovers from previous builds.

## Solution

Add a cleanup step **before building** to remove any existing RPM files for the package being built:

```yaml
- name: Clean previous RPM builds
  run: |
    rm -f ~/rpmbuild/RPMS/riscv64/docker-cli-*.rpm
    echo "Cleaned previous docker-cli RPM files"
```

## Changes

Added cleanup steps to all RPM build workflows:

1. **build-cli-rpm.yml**: Clean `docker-cli-*.rpm`
2. **build-rpm-package.yml**: Clean `moby-engine-*`, `containerd-*`, `runc-*.rpm`
3. **build-compose-rpm.yml**: Clean `docker-compose-plugin-*.rpm`
4. **build-tini-rpm.yml**: Clean `tini-*.rpm`, `tini-static-*.rpm`

## Testing

After merge:
1. Trigger any RPM build workflow
2. Verify only the NEW RPM version is uploaded to the release
3. Check that old versions don't appear

## Impact

- **Severity**: Medium - confusing for users but doesn't break functionality
- **Scope**: All RPM packages
- **User Impact**: Users might download wrong version if not careful

## Follow-up

Consider manually cleaning up the duplicate RPMs from existing releases:
- v28.5.2-riscv64
- cli-v28.5.2-riscv64
- compose-v2.40.1-riscv64
- tini-v0.19.0-riscv64

---

Ready for review and merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build workflows to clean up previous RPM artifacts before building new releases, ensuring only the latest packages are deployed and preventing accidental distribution of outdated versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->