### PR TITLE
fix(buildx): correct release tag detection in package workflows

### DIFF
--- a/.github/workflows/build-buildx-package.yml
+++ b/.github/workflows/build-buildx-package.yml
@@ -39,10 +39,10 @@ jobs:
           fi
 
           # Find the latest Buildx release
+          # gh release list outputs: Title<TAB>Status<TAB>Tag<TAB>Date
+          # We need to match the tag (column 3), not the title
           RELEASE_TAG=$(gh release list --repo gounthar/docker-for-riscv64 --limit 10 | \
-                        grep -E '^buildx-v[0-9]+\.[0-9]+\.[0-9]+-riscv64' | \
-                        head -1 | \
-                        awk '{print $1}')
+                        awk -F'\t' '$3 ~ /^buildx-v[0-9]+\.[0-9]+\.[0-9]+-riscv64$/ {print $3; exit}')
 
           if [ -z "$RELEASE_TAG" ]; then
             echo "No Buildx release found - skipping package build"

--- a/.github/workflows/build-buildx-rpm.yml
+++ b/.github/workflows/build-buildx-rpm.yml
@@ -40,10 +40,10 @@ jobs:
           fi
 
           # Find the latest Buildx release
+          # gh release list outputs: Title<TAB>Status<TAB>Tag<TAB>Date
+          # We need to match the tag (column 3), not the title
           RELEASE_TAG=$(gh release list --repo gounthar/docker-for-riscv64 --limit 10 | \
-                        grep -E '^buildx-v[0-9]+\.[0-9]+\.[0-9]+-riscv64' | \
-                        head -1 | \
-                        awk '{print $1}')
+                        awk -F'\t' '$3 ~ /^buildx-v[0-9]+\.[0-9]+\.[0-9]+-riscv64$/ {print $3; exit}')
 
           if [ -z "$RELEASE_TAG" ]; then
             echo "No Buildx release found - skipping package build"


### PR DESCRIPTION
## Problem

The buildx package workflows (`build-buildx-package.yml` and `build-buildx-rpm.yml`) are failing immediately after the binary build completes because they cannot detect the newly created buildx release.

**Root Cause**: The release detection logic was using `grep` to match the start of a line (`^buildx-v...`), but `gh release list` outputs tab-separated values where the tag is in **column 3**, not at the start of the line.

**Output format**: `Title<TAB>Status<TAB>Tag<TAB>Date`

Example:
```
Docker Buildx v0.19.2 for RISC-V64<TAB>Latest<TAB>buildx-v0.19.2-riscv64<TAB>2025-11-07T09:09:45Z
```

The grep pattern `^buildx-v...` was trying to match against "Docker Buildx v...", not the tag field.

## Solution

Changed both workflows to use `awk` with tab field separator (`-F'\t'`) to properly parse the release list output and match against column 3 (the tag field).

**Before**:
```bash
RELEASE_TAG=$(gh release list --repo gounthar/docker-for-riscv64 --limit 10 | \
              grep -E '^buildx-v[0-9]+\.[0-9]+\.[0-9]+-riscv64' | \
              head -1 | \
              awk '{print $1}')
```

**After**:
```bash
RELEASE_TAG=$(gh release list --repo gounthar/docker-for-riscv64 --limit 10 | \
              awk -F'\t' '$3 ~ /^buildx-v[0-9]+\.[0-9]+\.[0-9]+-riscv64$/ {print $3; exit}')
```

## Changes

- ✅ Fixed `build-buildx-package.yml` release detection
- ✅ Fixed `build-buildx-rpm.yml` release detection
- ✅ Added explanatory comments about the tab-separated format
- ✅ Tested locally - command now correctly returns `buildx-v0.19.2-riscv64`

## Testing

```bash
$ gh release list --limit 10 | awk -F'\t' '$3 ~ /^buildx-v[0-9]+\.[0-9]+\.[0-9]+-riscv64$/ {print $3; exit}'
buildx-v0.19.2-riscv64
```

## Impact

This unblocks the buildx packaging pipeline. After merging:
- Debian package workflow will detect the buildx release and build `.deb` package
- RPM package workflow will detect the buildx release and build `.rpm` package

## Related

- Buildx binary release created: buildx-v0.19.2-riscv64
- Failed package runs: #19163613100 (Debian), #19163613110 (RPM)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release tag detection in build workflows for improved reliability and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->