### PR TITLE
fix(buildx): add build-essential dependency and correct architecture field

### DIFF
--- a/.github/workflows/build-buildx-package.yml
+++ b/.github/workflows/build-buildx-package.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y debhelper dh-make dpkg-dev lintian devscripts libdistro-info-perl
+          sudo apt-get install -y build-essential debhelper dh-make dpkg-dev lintian devscripts libdistro-info-perl
           if ! command -v gh >/dev/null 2>&1; then
             sudo apt-get install -y gh || true
           fi

--- a/debian-buildx/control
+++ b/debian-buildx/control
@@ -9,7 +9,7 @@ Vcs-Browser: https://github.com/gounthar/docker-for-riscv64
 Vcs-Git: https://github.com/gounthar/docker-for-riscv64.git
 
 Package: docker-buildx-plugin
-Architecture: any
+Architecture: riscv64
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Recommends: docker.io (>= 20.10) | docker-ce (>= 20.10)
 Description: Docker CLI plugin for extended build capabilities


### PR DESCRIPTION
## Problem

The Debian package build for buildx was failing with:
```
dpkg-checkbuilddeps: error: Unmet build dependencies: build-essential:native
```

Additionally, Issue #93 identified that the Architecture field in `debian-buildx/control` was incorrectly set to `any` instead of `riscv64`.

## Solutions

### 1. Add build-essential Dependency
Added `build-essential` to the workflow's `apt-get install` command. While we're using pre-built binaries, `dpkg-buildpackage` still requires build-essential to be present.

### 2. Fix Architecture Field
Changed `Architecture` from `any` to `riscv64` in `debian-buildx/control`. This package only contains RISC-V64 binaries and should not be installable on other architectures.

## Changes

**File: `.github/workflows/build-buildx-package.yml`**
```diff
- sudo apt-get install -y debhelper dh-make dpkg-dev lintian devscripts libdistro-info-perl
+ sudo apt-get install -y build-essential debhelper dh-make dpkg-dev lintian devscripts libdistro-info-perl
```

**File: `debian-buildx/control`**
```diff
- Architecture: any
+ Architecture: riscv64
```

## Testing

Will test by triggering the Debian package workflow after merge.

## Related

- Closes #93 (Architecture field issue)
- Fixes Debian package build failure from run #19164561681

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure dependencies and package architecture configuration to target RISC-V 64-bit systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->