### PR TITLE
fix(buildx): use self-hosted riscv64 runner for Debian package build

### DIFF
--- a/.github/workflows/build-buildx-package.yml
+++ b/.github/workflows/build-buildx-package.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build-deb:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, riscv64]
     if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
 
     steps:


### PR DESCRIPTION
## Problem

Building Debian packages for buildx on `ubuntu-latest` (amd64) fails with:

```
dpkg-buildpackage: info: host architecture amd64
...
dpkg-genbuildinfo: error: binary build with no binary artifacts found; .buildinfo is meaningless
```

The issue is that dpkg-buildpackage detects the **host architecture** as amd64, but the binary we're packaging is riscv64. This creates a mismatch where dpkg-genbuildinfo can't find any amd64 binary artifacts.

## Root Cause

Cross-architecture Debian package building requires either:
1. Native architecture build environment (riscv64 runner)
2. Complex cross-compilation setup with proper dpkg configuration

The current approach (download riscv64 binary + build on amd64) doesn't work without additional dpkg cross-compilation configuration.

## Solution

Use `[self-hosted, riscv64]` runner for Debian package builds, just like we do for:
- RPM package builds (already working)
- Binary compilation (already working)

This ensures dpkg-buildpackage runs on the correct architecture and can properly generate package metadata.

## Testing

After merge, will trigger Debian package build for buildx-v0.19.2-riscv64 on the riscv64 runner to verify the fix.

## Related

- Part of Docker Buildx implementation (Issue #89, PR #91)
- Fourth fix after PR #98 (release detection), PR #99 (build-essential), and PR #100 (compat file)
- Aligns with project strategy documented in CLAUDE.md section "Workflows using `[self-hosted, riscv64]`"

## Benefits

- Native architecture package building (no cross-compilation issues)
- Consistency with RPM workflow (already uses riscv64 runner)
- Proper package metadata generation
- Simpler workflow (no architecture mismatches)