### PR TITLE
fix: use self-hosted riscv64 runner for all Debian package builds

### DIFF
--- a/.github/workflows/build-cli-package.yml
+++ b/.github/workflows/build-cli-package.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build-deb:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, riscv64]
     if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
 
     steps:

--- a/.github/workflows/build-compose-package.yml
+++ b/.github/workflows/build-compose-package.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build-deb:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, riscv64]
     if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
 
     steps:

--- a/.github/workflows/build-debian-package.yml
+++ b/.github/workflows/build-debian-package.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build-deb:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, riscv64]
     if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
 
     steps:


### PR DESCRIPTION
## Problem

Building Debian packages on `ubuntu-latest` (amd64) causes architecture detection issues:

```
dpkg-buildpackage: info: host architecture amd64
dpkg-genbuildinfo: error: binary build with no binary artifacts found
```

The dpkg tools detect the **host architecture** as amd64, but the binaries we're packaging are riscv64. This creates a mismatch where dpkg-genbuildinfo can't find any amd64 binary artifacts.

## Solution

Use `[self-hosted, riscv64]` runner for **all** Debian package builds:
- ✅ `build-buildx-package.yml` (already fixed in PR #101)
- ✅ `build-debian-package.yml` (Docker Engine) - **updated in this PR**
- ✅ `build-compose-package.yml` (Docker Compose) - **updated in this PR**
- ✅ `build-cli-package.yml` (Docker CLI) - **updated in this PR**

This aligns with:
- All RPM workflows (already using riscv64 runner)
- The buildx Debian workflow (fixed in PR #101)

## Root Cause

Cross-architecture Debian packaging requires either:
1. Native architecture build environment (riscv64 runner) ✅
2. Complex cross-compilation setup with proper dpkg configuration

The previous approach (download riscv64 binary + build on amd64) doesn't work without additional dpkg cross-compilation configuration.

## Benefits

- **Native architecture detection**: dpkg-buildpackage runs on correct architecture
- **Proper package metadata**: Architecture tags generated correctly (riscv64, not amd64)
- **Consistency**: All package workflows (Debian and RPM) now use riscv64 runner
- **Simpler workflows**: No need for cross-compilation configuration
- **Proven approach**: Buildx Debian package built successfully after switching to riscv64

## Testing

After merge:
- Existing buildx package already verified working on riscv64
- Should monitor first automatic runs of Docker Engine, CLI, and Compose Debian package builds
- Can manually trigger if needed to verify immediately

## Related

- PR #101: Fixed buildx Debian package (proved native packaging works)
- Issue #89: Docker Buildx implementation (now complete)
- Follows runner strategy documented in CLAUDE.md (updated locally)

## Documentation

CLAUDE.md has been updated locally (it's in .gitignore) to reflect this strategy:

**Workflows using `[self-hosted, riscv64]`:**
- All binary compilation workflows
- All package building workflows (Debian and RPM)

**Workflows using `ubuntu-latest`:**
- API calls and tracking workflows
- Repository management (reprepro/createrepo_c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI build pipeline runner infrastructure for package builds across multiple workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->