### PR TITLE
feat(buildx): add automated release tracking workflow

### DIFF
--- a/.github/workflows/track-buildx-releases.yml
+++ b/.github/workflows/track-buildx-releases.yml
@@ -1,0 +1,94 @@
+name: Track Docker Buildx Releases
+
+on:
+  schedule:
+    # Check for new releases daily at 08:00 UTC (after CLI tracking)
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  actions: write
+
+jobs:
+  check-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for new Docker Buildx release
+        id: check
+        run: |
+          # Get latest stable release from docker/buildx repository
+          LATEST=$(gh api repos/docker/buildx/releases/latest --jq '.tag_name')
+
+          echo "latest_release=$LATEST" >> $GITHUB_OUTPUT
+
+          # Check if we've already built this (using buildx-v*-riscv64 format)
+          # Docker Buildx tags are like v0.29.1, we create buildx-v0.29.1-riscv64
+          CLEAN_VERSION="${LATEST#v}"
+          OUR_TAG="buildx-v${CLEAN_VERSION}-riscv64"
+
+          if gh release view "${OUR_TAG}" >/dev/null 2>&1; then
+            echo "already_built=true" >> $GITHUB_OUTPUT
+          else
+            echo "already_built=false" >> $GITHUB_OUTPUT
+          fi
+
+          echo "Latest Docker Buildx release: $LATEST"
+          echo "Checking for: ${OUR_TAG}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Trigger automatic build for new release
+        if: steps.check.outputs.already_built == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          LATEST=${{ steps.check.outputs.latest_release }}
+
+          echo "New Docker Buildx release detected: $LATEST"
+          echo "Triggering automatic build..."
+
+          # Trigger the build workflow with the version tag
+          gh workflow run buildx-weekly-build.yml -f buildx_ref=$LATEST
+
+          # Create tracking issue
+          CLEAN_VERSION="${LATEST#v}"
+          cat > issue-body.md << EOF
+          New Docker Buildx release detected: **$LATEST**
+
+          **Status:** Build automatically triggered
+
+          The buildx-weekly-build workflow has been started automatically.
+          Expected completion time: ~35-40 minutes on self-hosted riscv64 runner
+
+          **Monitor build progress:**
+          \`\`\`bash
+          gh run list --workflow=buildx-weekly-build.yml --limit 1
+          gh run watch
+          \`\`\`
+
+          **Expected release:** buildx-v${CLEAN_VERSION}-riscv64
+
+          **Upstream release notes:** https://github.com/docker/buildx/releases/tag/$LATEST
+
+          **What is Docker Buildx?**
+          Docker Buildx is a CLI plugin that extends the docker build command with the full BuildKit features, including:
+          - Multi-platform builds (--platform flag)
+          - Advanced caching strategies
+          - Build-time secrets and SSH forwarding
+          - Remote builder support
+
+          This issue will track the build progress. Close it once the release is published.
+          EOF
+
+          gh issue create \
+            --title "Building Docker Buildx ${LATEST} for RISC-V64" \
+            --body-file issue-body.md \
+            --label "build-in-progress,buildx-release"
+
+          echo "Build triggered successfully!"


### PR DESCRIPTION
## Summary

Adds automated daily tracking for new Docker Buildx releases from upstream (docker/buildx repository).

## Problem

We built v0.19.2, but the latest upstream is **v0.29.1** (Issue #95). We had no automated way to detect new buildx releases.

Existing tracking:
- ✅ Docker Engine: `track-moby-releases.yml`
- ✅ Docker CLI: `track-cli-releases.yml`
- ❌ Docker Buildx: **Missing**

## Solution

New workflow: `.github/workflows/track-buildx-releases.yml`

**Behavior:**
- Runs daily at 08:00 UTC (after CLI tracking)
- Checks `docker/buildx` latest release via GitHub API
- Compares against our `buildx-v*-riscv64` release tags
- Automatically triggers `buildx-weekly-build.yml` for new releases
- Creates tracking issue with `build-in-progress` label

**Example output:**
```bash
# When v0.29.2 is released upstream
Latest Docker Buildx release: v0.29.2
Checking for: buildx-v0.29.2-riscv64
New Docker Buildx release detected: v0.29.2
Triggering automatic build...
Build triggered successfully!
```

## Testing

Can be tested immediately with:
```bash
gh workflow run track-buildx-releases.yml
```

This should detect v0.29.1 as a new release (since we just triggered a manual build that hasn't completed yet).

## Benefits

- **Automatic detection**: No manual checking of upstream releases
- **Immediate builds**: New releases trigger builds within hours
- **Tracking issues**: Automated issue creation for visibility
- **Consistency**: Matches existing tracking patterns for Moby and CLI

## Related

- Issue #89: Docker Buildx implementation
- PR #91: Initial buildx implementation  
- Issue #95: Version verification (0.19.2 vs 0.29.1) - **addressed by this PR**
- Currently building v0.29.1 manually (triggered before this PR)

## Documentation

CLAUDE.md will be updated locally (it's in .gitignore) to add:
- `track-buildx-releases.yml` to the tracking workflows list
- Note about automated buildx version detection