### PR TITLE
fix(apt-repo): add Docker Buildx package workflow to APT repo triggers

### DIFF
--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -2,13 +2,13 @@ name: Update APT Repository
 
 on:
   workflow_run:
-    workflows: ["Build Debian Package", "Build Docker Compose Debian Package", "Build Docker CLI Debian Package"]
+    workflows: ["Build Debian Package", "Build Docker Compose Debian Package", "Build Docker CLI Debian Package", "Build Docker Buildx Debian Package"]
     types: [completed]
     branches: [main]
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Release tag containing the .deb package (v*-riscv64, compose-v*-riscv64, or cli-v*-riscv64)'
+        description: 'Release tag containing the .deb package (v*-riscv64, compose-v*-riscv64, cli-v*-riscv64, or buildx-v*-riscv64)'
         required: true
         default: 'v28.5.1-riscv64'
 


### PR DESCRIPTION
## Problem

After building Docker Buildx v0.29.1 and v0.19.2 packages, they weren't appearing in the APT repository when running `apt list --upgradable` or `apt upgrade`.

**Root cause:** The APT repository update workflow (`update-apt-repo.yml`) was missing `"Build Docker Buildx Debian Package"` from its `workflow_run` trigger list.

**Current triggers:**
- ✅ "Build Debian Package" (Docker Engine)
- ✅ "Build Docker Compose Debian Package"
- ✅ "Build Docker CLI Debian Package"
- ❌ **Missing**: "Build Docker Buildx Debian Package"

## Solution

Added `"Build Docker Buildx Debian Package"` to the workflow_run trigger list:

```yaml
workflow_run:
  workflows: [
    "Build Debian Package",
    "Build Docker Compose Debian Package",
    "Build Docker CLI Debian Package",
    "Build Docker Buildx Debian Package"  # NEW
  ]
```

Also updated the manual trigger description to include `buildx-v*-riscv64` tag format.

## Impact

**After this PR:**
- Future buildx Debian package builds will automatically trigger APT repo updates
- Buildx packages will be available via `apt install docker-buildx-plugin`

**Current packages:**
- buildx-v0.19.2-riscv64 and buildx-v0.29.1-riscv64 require manual APT repo update (will do after merge)

## Testing

After merge, manually trigger APT repo update:
```bash
gh workflow run update-apt-repo.yml -f release_tag=buildx-v0.29.1-riscv64
```

Then verify on BananaPi F3:
```bash
sudo apt update
apt list --upgradable | grep buildx
```

## Related

- Issue #89: Docker Buildx implementation
- PR #91: Initial buildx workflows
- PR #103: Buildx release tracking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to support expanded build automation and release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->