### PR TITLE
fix(apt-repo): add Docker Buildx package download to APT repository workflow

### DIFF
--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -10,7 +10,7 @@ on:
       release_tag:
         description: 'Release tag containing the .deb package (v*-riscv64, compose-v*-riscv64, cli-v*-riscv64, or buildx-v*-riscv64)'
         required: true
-        default: 'v28.5.1-riscv64'
+        default: 'v28.5.2-riscv64'
 
 jobs:
   update-repo:
@@ -89,6 +89,13 @@ jobs:
                             jq -r '.[] | select(.tagName | test("^compose-v[0-9]+\\.[0-9]+\\.[0-9]+-riscv64$")) | .tagName' | \
                             head -1)
           echo "Latest Compose release: $COMPOSE_RELEASE"
+
+          # Find latest Buildx release
+          BUILDX_RELEASE=$(gh release list --repo gounthar/docker-for-riscv64 \
+                           --limit 50 --json tagName | \
+                           jq -r '.[] | select(.tagName | test("^buildx-v[0-9]+\\.[0-9]+\\.[0-9]+-riscv64$")) | .tagName' | \
+                           head -1)
+          echo "Latest Buildx release: $BUILDX_RELEASE"
           echo ""
 
           # Download Engine packages (docker.io, containerd, runc)
@@ -116,10 +123,17 @@ jobs:
               --repo gounthar/docker-for-riscv64 --clobber || true
           fi
 
+          # Download Buildx package
+          if [ -n "$BUILDX_RELEASE" ]; then
+            echo "Downloading Buildx package from $BUILDX_RELEASE..."
+            gh release download "$BUILDX_RELEASE" -p 'docker-buildx-plugin_*.deb' \
+              --repo gounthar/docker-for-riscv64 --clobber || true
+          fi
+
           echo ""
           echo "Cleaning up: keeping only the latest version of each package..."
           # For each package prefix, keep only the newest file (by timestamp)
-          for pattern in docker.io docker-cli docker-compose-plugin containerd runc; do
+          for pattern in docker.io docker-cli docker-compose-plugin docker-buildx-plugin containerd runc; do
             # Get all matching files sorted by modification time (newest first)
             # Keep the first (newest), delete the rest
             ls -t ${pattern}_*.deb 2>/dev/null | tail -n +2 | xargs -r rm -v


### PR DESCRIPTION
## Problem

After implementing buildx builds and fixing the workflow trigger in PR #104, buildx packages were still not appearing in the APT repository. The workflow was triggered correctly, but the download logic was incomplete.

**Root Cause:** The APT repository update workflow only had logic to download Engine, CLI, and Compose packages. It was missing buildx entirely.

**User Impact:** Users could not install `docker-buildx-plugin` via apt despite successful package builds:
```bash
sudo apt update
# Shows: "Tous les paquets sont à jour" (All packages up to date)
sudo apt install docker-buildx-plugin
# Package not found
```

## Solution

Added complete buildx support to the APT repository workflow:

1. **Release Detection**: Added buildx release detection using `buildx-v[0-9]+\.[0-9]+\.[0-9]+-riscv64` pattern
2. **Package Download**: Added download logic for `docker-buildx-plugin_*.deb` files
3. **Cleanup**: Included `docker-buildx-plugin` in the cleanup loop to remove old versions

## Changes

- Add buildx release detection after Compose detection
- Add buildx package download section
- Update cleanup loop: `docker.io docker-cli docker-compose-plugin docker-buildx-plugin containerd runc`
- Update default release tag example to v28.5.2

## Testing Plan

After merge:
1. Manually trigger APT repo update with buildx-v0.29.1-riscv64
2. Verify buildx package appears in repository
3. Test installation: `sudo apt update && sudo apt install docker-buildx-plugin`

## Related Issues

- Fixes the issue where buildx not in APT repo (implicit issue from user reports)
- Follows up on: #104 (workflow trigger fix - only fixed triggering, not download)
- Related to: #103 (automated buildx release tracking)
- Related to: #95 (initial buildx v0.29.1 build)

## Workflow Logs Evidence

Previous run showed only Engine, CLI, and Compose downloaded:
```
Downloaded packages:
-rw-r--r-- 1 runner runner  12M Nov  7 10:49 containerd_1.7.28-1_riscv64.deb
-rw-r--r-- 1 runner runner  16M Nov  7 10:49 docker-cli_28.5.2-riscv64-1_riscv64.deb
-rw-r--r-- 1 runner runner  12M Nov  7 10:49 docker-compose-plugin_2.40.1-riscv64-1_riscv64.deb
-rw-r--r-- 1 runner runner  19M Nov  7 10:49 docker.io_28.5.2-1_riscv64.deb
-rw-r--r-- 1 runner runner 3.1M Nov  7 10:49 runc_1.3.0-1_riscv64.deb
# NO BUILDX!
```

After this fix, buildx packages will be downloaded and added to the repository.