### PR TITLE
fix(ci): handle rebase abort when no rebase in progress

### DIFF
--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -286,7 +286,10 @@ jobs:
                   echo "✅ Rebased successfully, retrying push..."
                 else
                   echo "⚠️  Rebase conflict detected. Resolving by accepting remote changes and re-adding package..."
-                  git rebase --abort
+                  # Only abort if rebase is actually in progress
+                  if git status | grep -q "rebase in progress"; then
+                    git rebase --abort
+                  fi
 
                   # Reset to remote state
                   git reset --hard origin/apt-repo


### PR DESCRIPTION
## Summary

Fixes a fatal error in the APT repository update workflow that was causing workflow failures with exit code 128.

## Problem

The workflow was failing at the rebase conflict resolution step:
1. `git rebase origin/apt-repo` would fail with "cannot rebase: You have unstaged changes"
2. The workflow would then try to run `git rebase --abort`
3. This would fail with "fatal: no rebase in progress" because the rebase never actually started

Error from workflow run: https://github.com/gounthar/docker-for-riscv64/actions/runs/19189188992

## Solution

Added a check to verify if a rebase is actually in progress before attempting to abort it:
```bash
if git status | grep -q "rebase in progress"; then
  git rebase --abort
fi
```

This allows the workflow to gracefully continue with the reset and retry logic instead of failing with exit code 128.

## Testing

- [x] Workflow YAML syntax validated (will be checked by CI)
- [ ] Manual workflow run to verify the fix works (will test after merge)

## Related

- Fixes workflow run: https://github.com/gounthar/docker-for-riscv64/actions/runs/19189188992
- Related to APT repository automation improvements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository update workflow with improved conflict handling during rebase operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->