### PR TITLE
fix(ci): add rpmdevtools package to RPM build workflows

### DIFF
--- a/.github/workflows/build-buildx-rpm.yml
+++ b/.github/workflows/build-buildx-rpm.yml
@@ -69,7 +69,7 @@ jobs:
             sudo dnf install -y rpm-build rpmdevtools rpmlint
           elif [ -f /etc/debian_version ]; then
             sudo apt-get update
-            sudo apt-get install -y rpm rpmlint
+            sudo apt-get install -y rpm rpmdevtools rpmlint
           fi
 
       - name: Set up RPM build tree

--- a/.github/workflows/build-cli-rpm.yml
+++ b/.github/workflows/build-cli-rpm.yml
@@ -37,7 +37,7 @@ jobs:
             sudo dnf install -y rpm-build rpmdevtools rpmlint
           elif [ -f /etc/debian_version ]; then
             sudo apt-get update
-            sudo apt-get install -y rpm rpmlint
+            sudo apt-get install -y rpm rpmdevtools rpmlint
           fi
 
       - name: Set up RPM build tree

--- a/.github/workflows/build-compose-rpm.yml
+++ b/.github/workflows/build-compose-rpm.yml
@@ -37,7 +37,7 @@ jobs:
             sudo dnf install -y rpm-build rpmdevtools rpmlint
           elif [ -f /etc/debian_version ]; then
             sudo apt-get update
-            sudo apt-get install -y rpm rpmlint
+            sudo apt-get install -y rpm rpmdevtools rpmlint
           fi
 
       - name: Set up RPM build tree

--- a/.github/workflows/build-tini-rpm.yml
+++ b/.github/workflows/build-tini-rpm.yml
@@ -52,7 +52,7 @@ jobs:
             sudo dnf install -y rpm-build rpmdevtools rpmlint
           elif [ -f /etc/debian_version ]; then
             sudo apt-get update
-            sudo apt-get install -y rpm rpmlint
+            sudo apt-get install -y rpm rpmdevtools rpmlint
           fi
 
       - name: Set up RPM build tree


### PR DESCRIPTION
## Summary
- Fixes missing `rpmdevtools` package in RPM build workflows on Debian-based systems
- Resolves "rpmdev-setuptree: command not found" error

## Problem
The RPM build workflows were failing on Debian-based systems (self-hosted riscv64 runner and ubuntu-latest) because the "Install build dependencies" step was missing the `rpmdevtools` package.

## Solution
Added `rpmdevtools` to the Debian installation branch in all four RPM workflows:
- `.github/workflows/build-cli-rpm.yml`
- `.github/workflows/build-compose-rpm.yml`
- `.github/workflows/build-tini-rpm.yml`
- `.github/workflows/build-buildx-rpm.yml`

## Test plan
- [x] Verified all workflow files have consistent dependency installation
- [ ] Test workflows run successfully after merge

## Related
Fixes failed workflow run: https://github.com/gounthar/docker-for-riscv64/actions/runs/19205061800

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build pipeline configuration to include additional RPM packaging dependencies in Debian-based build environments, improving build consistency across multiple workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->