### PR TITLE
fix(ci): correct RPM repository workflow to use rpm-repo branch

### DIFF
--- a/.github/workflows/update-rpm-repo.yml
+++ b/.github/workflows/update-rpm-repo.yml
@@ -18,10 +18,10 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
 
     steps:
-      - name: Checkout apt-repo branch
+      - name: Checkout rpm-repo branch
         uses: actions/checkout@v5
         with:
-          ref: apt-repo
+          ref: rpm-repo
           fetch-depth: 0
 
       - name: Install dependencies
@@ -253,7 +253,10 @@ jobs:
 
           git add rpm/
           git commit -m "feat: add RPM packages from $RELEASE_TAG to repository" || echo "No changes to commit"
-          git push origin apt-repo
+
+          # Pull and rebase to avoid conflicts with concurrent updates
+          git pull --rebase origin rpm-repo || true
+          git push origin rpm-repo
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary
- Fixes incorrect branch usage in "Update RPM Repository" workflow
- Changes from `apt-repo` to `rpm-repo` for both checkout and push
- Adds pull-rebase to handle concurrent updates

## Problem
The workflow was trying to update the APT repository branch (`apt-repo`) with RPM packages, causing:
1. **Wrong branch checkout**: Checked out `apt-repo` instead of `rpm-repo`
2. **Wrong branch push**: Pushed to `apt-repo` instead of `rpm-repo`
3. **Push conflicts**: Git rejected pushes with "fetch first" error

## Root Cause
Copy-paste error - the RPM repo workflow was based on the APT repo workflow but branch names weren't updated.

## Solution
1. Changed checkout ref: `apt-repo` → `rpm-repo` (.github/workflows/update-rpm-repo.yml:24)
2. Changed push target: `apt-repo` → `rpm-repo` (.github/workflows/update-rpm-repo.yml:259)
3. Added `git pull --rebase` before push to handle concurrent updates (.github/workflows/update-rpm-repo.yml:258)
4. Updated to `actions/checkout@v5` (merged from main)

## Test plan
- [x] Verified workflow file has correct branch references
- [x] Added rebase step to prevent race conditions
- [ ] Test workflow runs successfully after merge

## Related
Fixes failed workflow run: https://github.com/gounthar/docker-for-riscv64/actions/runs/19204497143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for RPM repository operations, including improved conflict prevention and automated rebase procedures during the publishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->