### PR TITLE
feat(workflows): improve error handling in retry logic for APT/RPM workflows

### DIFF
--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -286,8 +286,8 @@ jobs:
                   echo "✅ Rebased successfully, retrying push..."
                 else
                   echo "⚠️  Rebase conflict detected. Resolving by accepting remote changes and re-adding package..."
-                  # Only abort if rebase is actually in progress
-                  if git status | grep -q "rebase in progress"; then
+                  # Only abort if rebase is actually in progress (check filesystem state)
+                  if [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]; then
                     git rebase --abort
                   fi
 
@@ -313,7 +313,7 @@ jobs:
                   done
 
                   # Commit again if there are changes
-                  if ! git diff --quiet dists pool 2>/dev/null; then
+                  if ! git diff --quiet dists pool; then
                     git add dists pool
                     git commit -m "Add $PACKAGE_NAME $VERSION from release $RELEASE_TAG" \
                                -m "Automated update from GitHub Actions (retry $RETRY_COUNT)." \

--- a/.github/workflows/update-rpm-repo.yml
+++ b/.github/workflows/update-rpm-repo.yml
@@ -291,8 +291,8 @@ jobs:
                   echo "✅ Rebased successfully, retrying push..."
                 else
                   echo "⚠️  Rebase conflict detected. Resolving by accepting remote changes and re-adding packages..."
-                  # Only abort if rebase is actually in progress
-                  if git status | grep -q "rebase in progress"; then
+                  # Only abort if rebase is actually in progress (check filesystem state)
+                  if [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]; then
                     git rebase --abort
                   fi
 
@@ -314,8 +314,13 @@ jobs:
                     exit 1
                   fi
 
-                  # Re-import GPG key (may have been cleared by reset)
-                  echo "$GPG_PRIVATE_KEY" | gpg --batch --import 2>/dev/null || true
+                  # Re-import GPG key if needed (idempotent check)
+                  if ! gpg --list-secret-keys 56188341425B007407229B48FB1963FC3575A39D &>/dev/null; then
+                    echo "Re-importing GPG signing key..."
+                    echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+                  else
+                    echo "GPG key already present, skipping re-import"
+                  fi
 
                   # Regenerate repository metadata
                   echo "Regenerating repository metadata..."
@@ -334,7 +339,7 @@ jobs:
                   cd ../../..
 
                   # Commit again if there are changes
-                  if ! git diff --quiet rpm/ 2>/dev/null; then
+                  if ! git diff --quiet rpm/; then
                     git add rpm/
                     git commit -m "feat: add RPM packages from $RELEASE_TAG to repository" \
                                -m "Automated update from GitHub Actions (retry $RETRY_COUNT)." \


### PR DESCRIPTION
## Summary
- Improves robustness of retry/recovery error handling in both APT and RPM workflows
- Addresses CodeRabbit feedback from PR #116
- Applies consistent patterns across both workflows

## Changes

### 1. Rebase Detection - Filesystem-Based (Both Workflows)

**Before:**
```bash
if git status | grep -q "rebase in progress"; then
  git rebase --abort
fi
```

**After:**
```bash
if [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]; then
  git rebase --abort
fi
```

**Why:**
- ✅ Git-version-independent (doesn't parse human-readable output)
- ✅ More robust across different git configurations
- ✅ Checks actual filesystem state, not output format
- **Locations**: APT:290, RPM:295

### 2. Git Diff Error Visibility (Both Workflows)

**Before:**
```bash
if ! git diff --quiet dists pool 2>/dev/null; then
```

**After:**
```bash
if ! git diff --quiet dists pool; then
```

**Why:**
- ✅ Surfaces real errors (permissions, missing paths) in workflow logs
- ✅ No silent error masking
- ✅ Better debugging when issues occur
- **Locations**: APT:316, RPM:342

### 3. GPG Key Re-import - Idempotent Check (RPM Workflow Only)

**Before:**
```bash
# Re-import GPG key (may have been cleared by reset)
echo "$GPG_PRIVATE_KEY" | gpg --batch --import 2>/dev/null || true
```

**After:**
```bash
# Re-import GPG key if needed (idempotent check)
if ! gpg --list-secret-keys 56188341425B007407229B48FB1963FC3575A39D &>/dev/null; then
  echo "Re-importing GPG signing key..."
  echo "$GPG_PRIVATE_KEY" | gpg --batch --import
else
  echo "GPG key already present, skipping re-import"
fi
```

**Why:**
- ✅ No `|| true` error masking (aligns with PR #116 goals)
- ✅ Idempotent - handles retry scenarios gracefully
- ✅ Clear logging of import vs skip decision
- ✅ Fails explicitly if import truly fails
- **Location**: RPM:318-323

**Note**: APT workflow doesn't use GPG in retry path, so no equivalent change needed.

## Benefits

| Benefit | Description |
|---------|-------------|
| **Consistency** | Same patterns applied to both APT and RPM workflows |
| **No Silent Failures** | All errors surface in logs with context |
| **Version Independence** | Filesystem checks don't depend on git output format |
| **Better Debugging** | Clear error messages and state indicators |
| **Idempotency** | Retry logic handles already-completed operations gracefully |

## Testing Strategy

- [x] Code review against issue requirements
- [x] Verified all changes align with CodeRabbit feedback
- [x] Confirmed consistency across both workflows
- [ ] Test with manual workflow dispatch
- [ ] Test with concurrent package builds (will happen naturally)
- [ ] Verify improved error messages in logs

## Rationale for Choices

### Why filesystem checks over `git status`?
Git's status output is designed for humans and can vary across versions, locales, and configurations. Checking `.git/rebase-merge` or `.git/rebase-apply` directly is the canonical way to detect rebase state.

### Why idempotent GPG check instead of `|| true`?
The `|| true` pattern masks **all** errors, including legitimate failures. The idempotent check:
- Succeeds when key is already present (expected in retries)
- Fails explicitly when import fails (unexpected, needs investigation)
- Provides clear logging for debugging

### Why remove `2>/dev/null` from git diff?
If `git diff` has stderr output, it usually indicates a real problem (permissions, corrupted repo, etc.) that should be visible in logs. Hiding it makes debugging harder.

## CodeRabbit Feedback Addressed

✅ **GPG Import Error Masking** - Replaced `|| true` with idempotent check  
✅ **Rebase Detection Fragility** - Using filesystem checks instead of output parsing  
✅ **Git Diff Stderr Redirect** - Removed to surface real errors

## Related

- Closes #117
- Follow-up to PR #116
- CodeRabbit review: https://github.com/gounthar/docker-for-riscv64/pull/116#pullrequestreview-3439751829

## Notes

These changes are pure improvements with no breaking changes. The workflows will continue to function exactly as before, but with better error handling and debugging capabilities.