### PR TITLE
refactor(workflows): extract GPG key ID to environment variable

### DIFF
--- a/.github/workflows/update-rpm-repo.yml
+++ b/.github/workflows/update-rpm-repo.yml
@@ -12,6 +12,9 @@ on:
         required: true
         default: 'v28.5.1-riscv64'
 
+env:
+  GPG_KEY_ID: '56188341425B007407229B48FB1963FC3575A39D'
+
 jobs:
   update-repo:
     runs-on: ubuntu-latest
@@ -315,11 +318,11 @@ jobs:
                   fi
 
                   # Re-import GPG key if needed (idempotent check)
-                  if ! gpg --list-secret-keys 56188341425B007407229B48FB1963FC3575A39D &>/dev/null; then
-                    echo "Re-importing GPG signing key..."
+                  if ! gpg --list-secret-keys ${{ env.GPG_KEY_ID }} &>/dev/null; then
+                    echo "Re-importing GPG signing key (${{ env.GPG_KEY_ID }})..."
                     echo "$GPG_PRIVATE_KEY" | gpg --batch --import
                   else
-                    echo "GPG key already present, skipping re-import"
+                    echo "GPG key ${{ env.GPG_KEY_ID }} already present, skipping re-import"
                   fi
 
                   # Regenerate repository metadata


### PR DESCRIPTION
Summary:
- Extracts hardcoded GPG key ID to workflow-level environment variable
- Improves maintainability and prepares for consistency across workflows
- Addresses Copilot feedback from PR #118

Problem:
The GPG key ID was hardcoded in the RPM workflow idempotent GPG import check. This violates DRY principle and makes key rotation more difficult.

Solution:
1. Add workflow-level env var: GPG_KEY_ID
2. Update GPG check to use env var
3. Update log messages to include key ID

Benefits:
- DRY principle: Define once, reference everywhere
- Easy key rotation: Change in one place
- Better maintainability and logging
- Consistent pattern for future workflows

Closes #120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository build workflow configuration for improved flexibility and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->