### PR TITLE
fix(ci): correct Docker Engine release detection in Debian package workflow

### DIFF
--- a/.github/workflows/build-debian-package.yml
+++ b/.github/workflows/build-debian-package.yml
@@ -30,6 +30,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "Manual dispatch - proceeding with build"
             echo "has_new_release=true" >> $GITHUB_OUTPUT
+            echo "release_tag=${{ github.event.inputs.release_tag }}" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -52,6 +53,7 @@ jobs:
           else
             echo "Release $RELEASE_TAG needs Debian packages - proceeding with build"
             echo "has_new_release=true" >> $GITHUB_OUTPUT
+            echo "release_tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
           fi
 
       - name: Install build dependencies
@@ -65,15 +67,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Get release tag from workflow_run or manual input
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            RELEASE_TAG="${{ github.event.inputs.release_tag }}"
-          else
-            # Find the latest docker release created by the workflow
-            RELEASE_TAG=$(gh release list --repo gounthar/docker-for-riscv64 --limit 10 --json tagName,createdAt | \
-                          jq -r '.[] | select(.tagName | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-riscv64$")) | .tagName' | \
-                          head -1)
-          fi
+          # Use release tag from check_release step
+          RELEASE_TAG="${{ steps.check_release.outputs.release_tag }}"
 
           echo "Building package for release: $RELEASE_TAG"
 
@@ -95,14 +90,8 @@ jobs:
       - name: Update package version in changelog
         if: steps.check_release.outputs.has_new_release == 'true'
         run: |
-          # Get release tag (same logic as download step)
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            RELEASE_TAG="${{ github.event.inputs.release_tag }}"
-          else
-            RELEASE_TAG=$(gh release list --repo gounthar/docker-for-riscv64 --limit 10 --json tagName,createdAt | \
-                          jq -r '.[] | select(.tagName | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-riscv64$")) | .tagName' | \
-                          head -1)
-          fi
+          # Use release tag from check_release step
+          RELEASE_TAG="${{ steps.check_release.outputs.release_tag }}"
           # Extract version from tag (v28.5.1-riscv64 -> 28.5.1)
           VERSION=$(echo $RELEASE_TAG | sed 's/^v//; s/-riscv64$//')
 
@@ -168,14 +157,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Get release tag (same logic as download step)
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            RELEASE_TAG="${{ github.event.inputs.release_tag }}"
-          else
-            RELEASE_TAG=$(gh release list --repo gounthar/docker-for-riscv64 --limit 10 --json tagName,createdAt | \
-                          jq -r '.[] | select(.tagName | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-riscv64$")) | .tagName' | \
-                          head -1)
-          fi
+          # Use release tag from check_release step
+          RELEASE_TAG="${{ steps.check_release.outputs.release_tag }}"
 
           echo "Uploading packages to release $RELEASE_TAG"
           echo ""


### PR DESCRIPTION
## Summary

Fixes the Docker Engine release detection logic in the Debian package build workflow that was preventing automatic package builds for v29.0.0-riscv64 and potentially future releases.

## Problem

The workflow used `grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-riscv64'` on the output of `gh release list`, which produces a formatted table:

```
Docker v29.0.0 for RISC-V64    Latest    v29.0.0-riscv64    2025-11-12T11:23:26Z
```

The grep pattern `^v[0-9]...` tries to match from the start of the line, but the line starts with "Docker v29.0.0...", not "v29.0.0-riscv64". This caused the workflow to skip builds with the message "No Docker release found - skipping package build".

## Solution

Changed all release detection logic to use `--json` output with `jq` for reliable parsing:

```bash
gh release list --repo gounthar/docker-for-riscv64 --limit 10 --json tagName,createdAt | \
  jq -r '.[] | select(.tagName | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-riscv64$")) | .tagName' | \
  head -1
```

This approach:
- Uses structured JSON data instead of formatted text
- Filters with regex on the tagName field directly
- Correctly excludes CLI, Compose, Buildx, and Tini releases
- Is more reliable and maintainable

## Changes

Fixed release detection in 4 places:
1. Check if new release exists step (line 37)
2. Download release binaries step (line 73)
3. Update package version in changelog step (line 102)
4. Upload packages to release step (line 175)

## Testing

- Manually triggered Debian package build for v29.0.0-riscv64 (workflow run #19324632809)
- Verified the new logic correctly detects `v29.0.0-riscv64` release
- Once merged, future Docker Engine releases should automatically trigger package builds

## Impact

After this fix:
- Docker Engine v29.0.0 packages will be available in the APT repository
- Future releases will automatically get Debian packages built
- Users will receive Docker Engine updates via `apt upgrade`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Debian package build workflow reliability by overhauling release detection and ensuring the selected release tag is consistently passed through all build steps.
  * Preserves manual trigger behavior and makes release selection clearer in logs, while maintaining existing handling when no new release is needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->