### PR TITLE
fix(ci): correct bash regex syntax for VERSION_REGEX usage

### DIFF
--- a/.github/workflows/docker-weekly-build.yml
+++ b/.github/workflows/docker-weekly-build.yml
@@ -48,7 +48,8 @@ jobs:
 
           # Determine version for Docker build
           # If checked out to a version tag (vX.Y.Z or docker-vX.Y.Z), extract clean version
-          if [[ "$MOBY_REF" =~ ${{ env.VERSION_REGEX }} ]]; then
+          VERSION_REGEX='${{ env.VERSION_REGEX }}'
+          if [[ "$MOBY_REF" =~ $VERSION_REGEX ]]; then
             # Official release tag: docker-v29.0.0 -> 29.0.0
             VERSION="${MOBY_REF#docker-}"
             VERSION="${VERSION#v}"
@@ -196,7 +197,8 @@ jobs:
           VERSION="${{ steps.moby_update.outputs.version }}"
 
           # Determine release version and title based on moby_ref
-          if [[ "$MOBY_REF" =~ ${{ env.VERSION_REGEX }} ]]; then
+          VERSION_REGEX='${{ env.VERSION_REGEX }}'
+          if [[ "$MOBY_REF" =~ $VERSION_REGEX ]]; then
             # Official release: docker-v29.0.0 -> v29.0.0-riscv64
             VERSION_TAG="${MOBY_REF#docker-}"
             RELEASE_VERSION="${VERSION_TAG}-riscv64"


### PR DESCRIPTION
## Summary

Hotfix for workflow syntax error that caused run #19329223053 to fail immediately after merging PR #130.

## Problem

GitHub Actions template syntax was used directly inside bash regex comparison:

```bash
if [[ "$MOBY_REF" =~ ${{ env.VERSION_REGEX }} ]]; then
```

This causes bash syntax errors because the template expansion happens at the wrong time, breaking the regex matching operator.

## Solution

Store the GitHub env variable in a bash variable first, then use it unquoted in the regex comparison:

```bash
VERSION_REGEX='${{ env.VERSION_REGEX }}'
if [[ "$MOBY_REF" =~ $VERSION_REGEX ]]; then
```

This allows proper bash regex matching while still using the centralized env variable for the pattern.

## Changes

Fixed in 2 locations:
1. **Update moby submodule step** (line 51)
2. **Create release step** (line 200)

## Testing

The workflow syntax validation should pass after this fix, allowing the build to proceed normally.

## Related

- Fixes workflow failure from PR #130 merge
- Resolves run #19329223053 failure