### PR TITLE
fix(workflows): correct multi-line string syntax in docker-weekly-build

### DIFF
--- a/.github/workflows/docker-weekly-build.yml
+++ b/.github/workflows/docker-weekly-build.yml
@@ -203,15 +203,12 @@ jobs:
             VERSION_TAG="${MOBY_REF#docker-}"
             RELEASE_VERSION="${VERSION_TAG}-riscv64"
             RELEASE_TITLE="Docker ${VERSION_TAG} for RISC-V64"
-            VERSION_INFO="**Docker Version:** ${VERSION_TAG}
-**Built Version:** ${VERSION}"
+            VERSION_INFO=$'**Docker Version:** '"${VERSION_TAG}"$'\n**Built Version:** '"${VERSION}"
           else
             # Development build: master -> v20251018-dev
             RELEASE_VERSION="v${DATE}-dev"
             RELEASE_TITLE="Docker RISC-V64 Development Build ${DATE}"
-            VERSION_INFO="**Moby Branch:** ${MOBY_REF}
-**Moby Commit:** ${MOBY_COMMIT}
-**Built Version:** ${VERSION}"
+            VERSION_INFO=$'**Moby Branch:** '"${MOBY_REF}"$'\n**Moby Commit:** '"${MOBY_COMMIT}"$'\n**Built Version:** '"${VERSION}"
           fi
 
           cat > release-notes.md << EOF


### PR DESCRIPTION
Multi-line string assignments for VERSION_INFO were causing YAML parsing errors. Fixed by using bash $'...' syntax with explicit \n characters for newlines instead of literal line breaks.

Changes:
- Line 206-207: Official release VERSION_INFO assignment
- Line 211: Development build VERSION_INFO assignment

Both now use proper bash $'...' syntax to handle multi-line strings within GitHub Actions YAML run blocks.

Fixes the workflow validation error on line 207.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build workflow configuration for improved clarity in version information handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->