### PR TITLE
fix(ci): add systemd-rpm-macros dependency for RPM builds

### DIFF
--- a/.github/workflows/build-rpm-package.yml
+++ b/.github/workflows/build-rpm-package.yml
@@ -35,10 +35,10 @@ jobs:
         run: |
           # Check if running on Fedora or Debian
           if [ -f /etc/fedora-release ]; then
-            sudo dnf install -y rpm-build rpmdevtools rpmlint createrepo_c
+            sudo dnf install -y rpm-build rpmdevtools rpmlint createrepo_c systemd-rpm-macros
           elif [ -f /etc/debian_version ]; then
             sudo apt-get update
-            sudo apt-get install -y rpm rpmlint createrepo-c
+            sudo apt-get install -y rpm rpmlint createrepo-c systemd
           else
             echo "Unsupported distribution"
             exit 1


### PR DESCRIPTION
## Summary
- Fixes RPM build failure caused by missing systemd-rpm-macros dependency
- Updates build-rpm-package.yml workflow to install required systemd packages

## Problem
The containerd and moby-engine RPM builds were failing with:
```
error: Failed build dependencies:
	systemd-rpm-macros is needed by containerd-1.7.28-1.riscv64
```

This occurred because the RPM spec files use systemd service integration macros (`%systemd_post`, `%systemd_preun`, etc.) which require systemd-rpm-macros to be available during the build.

## Solution
Added systemd packages to the workflow's dependency installation step:
- **Fedora**: Install `systemd-rpm-macros` package
- **Debian**: Install `systemd` package (provides RPM macros for building)

## Changes
- `.github/workflows/build-rpm-package.yml`: Updated "Install build dependencies" step

## Testing
- Workflow should now successfully build containerd and moby-engine RPM packages
- Automatic trigger after successful Docker Engine builds should complete

## Fixes
Closes #19330544205 (workflow run)

## Related Files
- `rpm-containerd/containerd.spec` (line 12: `BuildRequires: systemd-rpm-macros`)
- `rpm-docker/moby-engine.spec` (uses systemd macros)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build dependencies for Fedora and Debian distributions to support RPM package generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->