### PR TITLE
fix(ci): create systemd RPM macros for Debian-based builds

### DIFF
--- a/.github/workflows/build-rpm-package.yml
+++ b/.github/workflows/build-rpm-package.yml
@@ -49,6 +49,36 @@ jobs:
         run: |
           rpmdev-setuptree || mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
+      - name: Create systemd RPM macros for Debian
+        if: steps.release.outputs.has-new-release == 'true'
+        run: |
+          # On Debian, systemd-rpm-macros package doesn't exist
+          # Create the macros manually
+          if [ -f /etc/debian_version ]; then
+            sudo mkdir -p /usr/lib/rpm/macros.d
+            sudo tee /usr/lib/rpm/macros.d/macros.systemd > /dev/null <<'EOF'
+# Systemd RPM macros for Debian
+%systemd_post() \
+if [ $1 -eq 1 ] && [ -x "/usr/bin/systemctl" ]; then \
+  systemctl --no-reload preset %{?*} || : \
+fi \
+%{nil}
+
+%systemd_preun() \
+if [ $1 -eq 0 ] && [ -x "/usr/bin/systemctl" ]; then \
+  systemctl --no-reload disable --now %{?*} || : \
+fi \
+%{nil}
+
+%systemd_postun_with_restart() \
+if [ $1 -ge 1 ] && [ -x "/usr/bin/systemctl" ]; then \
+  systemctl try-restart %{?*} || : \
+fi \
+%{nil}
+EOF
+            echo "Created systemd RPM macros for Debian"
+          fi
+
       - name: Clean previous RPM builds
         if: steps.release.outputs.has-new-release == 'true'
         run: |


### PR DESCRIPTION
## Summary
- Creates systemd RPM macros file on Debian systems for RPM package builds
- Fixes missing systemd-rpm-macros dependency that doesn't exist on Debian

## Problem
The Docker Engine RPM build continues to fail with:
```
error: Failed build dependencies:
	systemd-rpm-macros is needed by containerd-1.7.28-1.riscv64
```

**Root Cause Analysis:**
- Fedora/RHEL distributions provide `systemd-rpm-macros` package
- Debian/Ubuntu do NOT have this package
- PR #133 attempted to fix by installing `systemd` package, but it doesn't provide RPM macros
- The spec files require these macros: `%systemd_post`, `%systemd_preun`, `%systemd_postun_with_restart`

## Solution
Create the systemd macros file manually on Debian systems:
- Location: `/usr/lib/rpm/macros.d/macros.systemd`
- Implements three required macros following Fedora's standard implementation:
  - `%systemd_post`: Enables/presets service on package install
  - `%systemd_preun`: Disables service on package uninstall  
  - `%systemd_postun_with_restart`: Restarts service on package upgrade

## Changes
- `.github/workflows/build-rpm-package.yml`: Added "Create systemd RPM macros for Debian" step

## Testing Plan
After merge:
1. Trigger RPM build manually: `gh workflow run build-rpm-package.yml -f release_tag=v29.0.0-riscv64`
2. Verify containerd and moby-engine RPMs build successfully
3. Check that systemd service scripts work correctly in %post/%preun sections

## Fixes
- Workflow run #19330812736
- Follow-up to PR #133

## Related Files
- `rpm-containerd/containerd.spec` (BuildRequires: systemd-rpm-macros, uses macros in %post/%preun/%postun)
- `rpm-docker/moby-engine.spec` (uses systemd macros for docker.service)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced the release build pipeline to improve RPM package generation on Debian systems. The build process now ensures proper systemd support during deployments, enhancing build reliability on Debian environments where certain system components may not be pre-installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->