### PR TITLE
fix(ci): resolve YAML syntax error in RPM macros heredoc

### DIFF
--- a/.github/workflows/build-rpm-package.yml
+++ b/.github/workflows/build-rpm-package.yml
@@ -56,26 +56,26 @@ jobs:
           # Create the macros manually
           if [ -f /etc/debian_version ]; then
             sudo mkdir -p /usr/lib/rpm/macros.d
-            sudo tee /usr/lib/rpm/macros.d/macros.systemd > /dev/null <<'EOF'
-# Systemd RPM macros for Debian
-%systemd_post() \
-if [ $1 -eq 1 ] && [ -x "/usr/bin/systemctl" ]; then \
-  systemctl --no-reload preset %{?*} || : \
-fi \
-%{nil}
+            sudo bash -c 'cat > /usr/lib/rpm/macros.d/macros.systemd' <<'MACROS_EOF'
+          # Systemd RPM macros for Debian
+          %systemd_post() \
+          if [ $1 -eq 1 ] && [ -x "/usr/bin/systemctl" ]; then \
+            systemctl --no-reload preset %{?*} || : \
+          fi \
+          %{nil}
 
-%systemd_preun() \
-if [ $1 -eq 0 ] && [ -x "/usr/bin/systemctl" ]; then \
-  systemctl --no-reload disable --now %{?*} || : \
-fi \
-%{nil}
+          %systemd_preun() \
+          if [ $1 -eq 0 ] && [ -x "/usr/bin/systemctl" ]; then \
+            systemctl --no-reload disable --now %{?*} || : \
+          fi \
+          %{nil}
 
-%systemd_postun_with_restart() \
-if [ $1 -ge 1 ] && [ -x "/usr/bin/systemctl" ]; then \
-  systemctl try-restart %{?*} || : \
-fi \
-%{nil}
-EOF
+          %systemd_postun_with_restart() \
+          if [ $1 -ge 1 ] && [ -x "/usr/bin/systemctl" ]; then \
+            systemctl try-restart %{?*} || : \
+          fi \
+          %{nil}
+          MACROS_EOF
             echo "Created systemd RPM macros for Debian"
           fi
 


### PR DESCRIPTION
## Summary
- Fixes YAML syntax error caused by `%` symbols at line start in heredoc content
- Properly indents macro content to prevent YAML directive interpretation

## Problem
Attempting to trigger the RPM build workflow resulted in:
```
Invalid workflow file: .github/workflows/build-rpm-package.yml#L61
You have an error in your yaml syntax on line 61
```

**Root Cause:**
The systemd RPM macros heredoc content had `%systemd_post()` starting at column 0 (line 61). In YAML, `%` at the start of a line is a directive indicator (like `%YAML` or `%TAG`), causing the parser to fail.

## Solution
Fixed by:
1. **Proper indentation**: Added consistent indentation to all macro content lines
2. **Clearer heredoc delimiter**: Changed from `EOF` to `MACROS_EOF` for clarity
3. **Improved command structure**: Used `bash -c 'cat > file'` for cleaner sudo execution

The macro content is now properly indented within the YAML run block, so the `%` symbols are treated as heredoc content, not YAML directives.

## Changes
- `.github/workflows/build-rpm-package.yml`: Fixed "Create systemd RPM macros for Debian" step

## Testing
After merge, the workflow file will pass YAML validation and allow:
```bash
gh workflow run build-rpm-package.yml -f release_tag=v29.0.0-riscv64
```

## Fixes
- YAML syntax error preventing workflow execution
- Follow-up to PR #134

## Technical Note
YAML requires special characters like `%`, `@`, `` ` ``, `|`, `>`, etc. to be properly quoted or indented when they appear in multi-line strings to avoid being interpreted as YAML syntax.