### PR TITLE
fix(ci): use fedorariscv/base image for RISC-V64 RPM builds

### DIFF
--- a/.github/workflows/build-rpm-package.yml
+++ b/.github/workflows/build-rpm-package.yml
@@ -100,14 +100,14 @@ jobs:
       - name: Build RPM packages in Fedora container
         if: steps.release.outputs.has-new-release == 'true'
         run: |
-          # Use Fedora container for proper RPM build environment
+          # Use Fedora RISC-V container for proper RPM build environment
           # This avoids Debian-specific issues with systemd-rpm-macros
           docker run --rm \
             -v ~/rpmbuild:/root/rpmbuild:Z \
             -v $PWD/rpm-docker:/rpm-docker:ro \
             -v $PWD/rpm-containerd:/rpm-containerd:ro \
             -v $PWD/rpm-runc:/rpm-runc:ro \
-            fedora:latest \
+            fedorariscv/base:latest \
             bash -c '
               set -euo pipefail
 
@@ -141,10 +141,10 @@ jobs:
       - name: Run rpmlint checks
         if: steps.release.outputs.has-new-release == 'true'
         run: |
-          # Run rpmlint inside Fedora container
+          # Run rpmlint inside Fedora RISC-V container
           docker run --rm \
             -v ~/rpmbuild:/root/rpmbuild:ro \
-            fedora:latest \
+            fedorariscv/base:latest \
             bash -c 'dnf install -y rpmlint && rpmlint /root/rpmbuild/RPMS/riscv64/*.rpm' || true
 
       - name: Package info


### PR DESCRIPTION
## Summary
Replaces `fedora:latest` with `fedorariscv/base:latest` to use proper RISC-V64 Fedora images for RPM builds.

## Problem

The workflow failed with platform mismatch error:
```
docker: Error response from daemon: image with reference fedora:latest 
was found but does not match the specified platform: wanted linux/riscv64, 
actual: linux/amd64.
```

**Root Cause:**
The official `fedora:latest` image from Docker Hub only supports amd64/arm64 platforms, not RISC-V64. We need to use RISC-V64-specific Fedora images.

## Solution

Use `fedorariscv/base:latest` from the official Fedora RISC-V Docker Hub organization:
- **Repository**: https://hub.docker.com/r/fedorariscv/base
- **Last Updated**: November 12, 2025
- **Architecture**: Native RISC-V64
- **Pulls**: 807
- **Contains**: Full Fedora base system with RPM tooling support

## Changes

Updated container image in two places:
1. **Build RPM packages step**: `fedora:latest` → `fedorariscv/base:latest`
2. **Run rpmlint checks step**: `fedora:latest` → `fedorariscv/base:latest`

## Testing Plan

After merge:
1. Trigger workflow: `gh workflow run build-rpm-package.yml -f release_tag=v29.0.0-riscv64`
2. Verify image pulls successfully on RISC-V64 runner
3. Verify RPM packages build with systemd-rpm-macros
4. Confirm packages are signed and uploaded

## Additional Context

**Fedora RISC-V Organization:**
The `fedorariscv` Docker Hub organization maintains official Fedora images for RISC-V64:
- `fedorariscv/base` - Base Fedora system (most recent)
- `fedorariscv/systemd` - Systemd-enabled variant
- `fedorariscv/toolbox` - Development toolbox
- Others for specific use cases

## Fixes

- Workflow run #19332332447
- Follows up on PR #137

## Related

- Issue #136: Container-based RPM builds
- Docker Hub: https://hub.docker.com/u/fedorariscv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container images used in the RPM build workflow to RISC-V specific versions.
  * Added clarifying comments to the build configuration for better workflow documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->