### PR TITLE
fix(ci): fix RPM file ownership after container build

### DIFF
--- a/.github/workflows/build-rpm-package.yml
+++ b/.github/workflows/build-rpm-package.yml
@@ -138,6 +138,14 @@ jobs:
           echo "RPM packages built successfully:"
           ls -lh ~/rpmbuild/RPMS/riscv64/
 
+      - name: Fix RPM file ownership
+        if: steps.release.outputs.has-new-release == 'true'
+        run: |
+          # RPMs were created by root inside container, fix ownership for host user
+          sudo chown -R $(id -u):$(id -g) ~/rpmbuild/RPMS/
+          echo "Fixed ownership of RPM files"
+          ls -lh ~/rpmbuild/RPMS/riscv64/
+
       - name: Run rpmlint checks
         if: steps.release.outputs.has-new-release == 'true'
         run: |


### PR DESCRIPTION
## Summary
Fixes permission denied error when signing RPM packages by correcting file ownership after container build.

## Problem

The RPM build succeeded in the Fedora container, but signing failed with:
```
error: /home/poddingue/rpmbuild/RPMS/riscv64/containerd-1.7.28-1.fc41.riscv64.rpm: 
open failed: Permission denied
```

**Root Cause:**
- The Fedora container runs as `root` user
- RPM files are created with `root:root` ownership
- Host user (`poddingue`) cannot access files for signing
- The `:Z` volume mount flag handles SELinux labels but not ownership

## Solution

Add a step immediately after container build to fix ownership:
```bash
sudo chown -R $(id -u):$(id -g) ~/rpmbuild/RPMS/
```

This changes ownership from `root:root` to the current user, allowing:
- GPG signing to read the RPM files
- Upload step to access the signed packages
- All subsequent host-side operations

## Changes

Added "Fix RPM file ownership" step after "Build RPM packages in Fedora container":
- Recursively changes ownership of `~/rpmbuild/RPMS/` directory
- Uses `$(id -u):$(id -g)` to get current user/group dynamically
- Lists files after fix for verification

## Testing Plan

After merge:
1. Trigger workflow: `gh workflow run build-rpm-package.yml -f release_tag=v29.0.0-riscv64`
2. Verify container build succeeds
3. Verify ownership fix runs
4. Verify signing step can access files
5. Confirm packages upload to release

## Alternative Approaches Considered

1. **Run container with user mapping**: Complex, requires user namespace setup
2. **Sign inside container**: Requires GPG key inside container (security concern)
3. **Use different volume mount**: Doesn't solve root ownership issue
4. **Current solution**: Simple, secure, effective ✅

## Fixes

- Workflow run #19333480211

## Related

- PR #137: Fedora container approach
- PR #138: RISC-V64 image fix
- Issue #136: Container-based builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated RPM package build workflow to ensure proper file ownership during release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->