### PR TITLE
fix(ci): prevent apt-repo cleanup from failing on missing .deb files

### DIFF
--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -170,7 +170,7 @@ jobs:
           for pattern in docker.io docker-cli docker-compose-plugin docker-buildx-plugin containerd runc cagent; do
             # Get all matching files sorted by modification time (newest first)
             # Keep the first (newest), delete the rest
-            ls -t ${pattern}_*.deb 2>/dev/null | tail -n +2 | xargs -r rm -v
+            ls -t ${pattern}_*.deb 2>/dev/null | tail -n +2 | xargs -r rm -v || true
           done
 
           echo ""


### PR DESCRIPTION
## Problem

The APT repository update workflow (run 19401612030) failed because the cleanup step tried to remove old `.deb` files for packages that had no `.deb` files downloaded.

This happens when:
- Development builds (which only contain binaries) are the latest release for a component
- Example: `cagent-v20251116-dev` contains only `cagent-linux-riscv64` binary, no `.deb` package

With `set -euo pipefail` enabled:
- The `ls -t cagent_*.deb` command fails when no files match the pattern
- Even though stderr is redirected with `2>/dev/null`, the non-zero exit code propagates through the pipeline
- This causes the entire script to exit prematurely

## Solution

Added `|| true` to line 173 in the cleanup loop to ensure the script continues even when no files match the glob pattern.

## Testing

This fix allows the workflow to complete successfully even when:
- Some package types have no `.deb` files
- Development builds are the latest releases
- The cleanup command encounters missing patterns

## Related Workflow Run

- Failed run: https://github.com/gounthar/docker-for-riscv64/actions/runs/19401612030

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error handling in the package repository update workflow to handle cleanup operations more gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->