### PR TITLE
fix(ci): exclude dev builds from RPM package workflows

### DIFF
--- a/.github/workflows/build-cagent-rpm.yml
+++ b/.github/workflows/build-cagent-rpm.yml
@@ -26,7 +26,7 @@ jobs:
         uses: ./.github/actions/get-release-tag
         with:
           release-tag-input: ${{ github.event.inputs.release_tag || '' }}
-          tag-pattern: '^cagent-v'
+          tag-pattern: '^cagent-v[0-9]+\.[0-9]+\.[0-9]+-riscv64$'
           asset-pattern: 'cagent.*\.rpm$'
           check-existing-assets: ${{ github.event_name != 'workflow_dispatch' }}
 

--- a/.github/workflows/build-cli-rpm.yml
+++ b/.github/workflows/build-cli-rpm.yml
@@ -26,7 +26,7 @@ jobs:
         uses: ./.github/actions/get-release-tag
         with:
           release-tag-input: ${{ github.event.inputs.release_tag || '' }}
-          tag-pattern: '^cli-v'
+          tag-pattern: '^cli-v[0-9]+\.[0-9]+\.[0-9]+-riscv64$'
           asset-pattern: 'docker-cli.*\.rpm$'
           check-existing-assets: ${{ github.event_name != 'workflow_dispatch' }}
 

--- a/.github/workflows/build-compose-rpm.yml
+++ b/.github/workflows/build-compose-rpm.yml
@@ -26,7 +26,7 @@ jobs:
         uses: ./.github/actions/get-release-tag
         with:
           release-tag-input: ${{ github.event.inputs.release_tag || '' }}
-          tag-pattern: '^compose-v'
+          tag-pattern: '^compose-v[0-9]+\.[0-9]+\.[0-9]+-riscv64$'
           asset-pattern: 'docker-compose-plugin.*\.rpm$'
           check-existing-assets: ${{ github.event_name != 'workflow_dispatch' }}
 

--- a/.github/workflows/build-tini-rpm.yml
+++ b/.github/workflows/build-tini-rpm.yml
@@ -41,7 +41,7 @@ jobs:
         uses: ./.github/actions/get-release-tag
         with:
           release-tag-input: ${{ github.event.inputs.release_tag || '' }}
-          tag-pattern: '^tini-v'
+          tag-pattern: '^tini-v[0-9]+\.[0-9]+\.[0-9]+-riscv64$'
           asset-pattern: 'tini.*\.rpm$'
           check-existing-assets: ${{ github.event_name != 'workflow_dispatch' }}
 


### PR DESCRIPTION
## Problem

RPM package build workflows failed when triggered by development builds:
- **Failed run**: https://github.com/gounthar/docker-for-riscv64/actions/runs/19402088895
- **Error**: `error: line 2: Illegal char '-' (0x2d) in: Version: 20251116-dev`

### Root Cause

RPM workflows used overly broad tag patterns that matched both stable releases and dev builds:
- `'^cli-v'` matches both `cli-v28.5.1-riscv64` (stable) and `cli-v20251116-dev` (dev)
- Dev builds don't include `.rpm` files, only binaries
- Dev tag format `20251116-dev` has hyphen, which is **illegal** in RPM `Version:` fields
- RPM spec only allows hyphens in the `Release:` field, not `Version:`

## Solution

Updated tag patterns in all RPM workflows to require semantic versioning (X.Y.Z) with `-riscv64` suffix:

| Workflow | Old Pattern | New Pattern |
|----------|-------------|-------------|
| `build-cli-rpm.yml` | `'^cli-v'` | `'^cli-v[0-9]+\.[0-9]+\.[0-9]+-riscv64$'` |
| `build-compose-rpm.yml` | `'^compose-v'` | `'^compose-v[0-9]+\.[0-9]+\.[0-9]+-riscv64$'` |
| `build-cagent-rpm.yml` | `'^cagent-v'` | `'^cagent-v[0-9]+\.[0-9]+\.[0-9]+-riscv64$'` |
| `build-tini-rpm.yml` | `'^tini-v'` | `'^tini-v[0-9]+\.[0-9]+\.[0-9]+-riscv64$'` |

This excludes dev builds (pattern: `*-v[0-9]{8}-dev`) from triggering RPM builds.

## Testing

After this change:
- ✅ Stable releases (e.g., `cli-v29.0.1-riscv64`) will trigger RPM builds
- ✅ Dev builds (e.g., `cli-v20251116-dev`) will be **ignored** by RPM workflows
- ✅ RPM `Version:` field will only contain valid semantic versions (no hyphens)

## Notes

- `build-buildx-rpm.yml` already had the correct pattern (no changes needed)
- Debian package workflows already have proper dev build detection logic
- This aligns RPM workflows with the existing `build-rpm-package.yml` pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated RPM build workflows to enforce stricter release tag validation across multiple components. Workflows now require tags to follow strict semantic versioning format (major.minor.patch) with a -riscv64 architecture suffix, replacing generic prefix matching. This ensures only properly formatted RISC-V 64-bit releases trigger the automated build pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->