### PR TITLE
fix(ci): add cagent release tracking trigger to Debian package workflow

### DIFF
--- a/.github/workflows/build-cagent-package.yml
+++ b/.github/workflows/build-cagent-package.yml
@@ -2,7 +2,7 @@ name: Build cagent Debian Package
 
 on:
   workflow_run:
-    workflows: ["Weekly cagent RISC-V64 Build"]
+    workflows: ["Weekly cagent RISC-V64 Build", "Track cagent Releases"]
     types: [completed]
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- Add missing "Track cagent Releases" trigger to Debian package workflow
- Aligns with RPM package workflow which already has this trigger

## Problem

The `build-cagent-package.yml` (Debian) was only triggered by:
- `Weekly cagent RISC-V64 Build`

While `build-cagent-rpm.yml` was triggered by:
- `Weekly cagent RISC-V64 Build`
- `Track cagent Releases`

This caused the cagent v1.9.14 release (detected by `track-cagent-releases.yml`) to only build the RPM package, not the Debian package.

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Once merged, manually trigger `build-cagent-package.yml` to build v1.9.14 Debian package
- [ ] Future releases from `track-cagent-releases.yml` should trigger both package workflows