### PR TITLE
fix(ci): add missing release tracking triggers to package workflows

### DIFF
--- a/.github/workflows/build-buildx-package.yml
+++ b/.github/workflows/build-buildx-package.yml
@@ -2,7 +2,7 @@ name: Build Docker Buildx Debian Package
 
 on:
   workflow_run:
-    workflows: ["Weekly Docker Buildx RISC-V64 Build"]
+    workflows: ["Weekly Docker Buildx RISC-V64 Build", "Track Docker Buildx Releases"]
     types: [completed]
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/build-buildx-rpm.yml
+++ b/.github/workflows/build-buildx-rpm.yml
@@ -2,7 +2,7 @@ name: Build Buildx RPM Package
 
 on:
   workflow_run:
-    workflows: ["Weekly Docker Buildx RISC-V64 Build"]
+    workflows: ["Weekly Docker Buildx RISC-V64 Build", "Track Docker Buildx Releases"]
     types: [completed]
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/build-cli-package.yml
+++ b/.github/workflows/build-cli-package.yml
@@ -2,7 +2,7 @@ name: Build Docker CLI Debian Package
 
 on:
   workflow_run:
-    workflows: ["Weekly Docker CLI RISC-V64 Build"]
+    workflows: ["Weekly Docker CLI RISC-V64 Build", "Track Docker CLI Releases"]
     types: [completed]
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- Add missing Track workflow triggers to CLI and Buildx package workflows
- Ensures packages are built when releases are detected, not just on weekly builds

## Changes

| Workflow | Added Trigger |
|----------|---------------|
| `build-cli-package.yml` | "Track Docker CLI Releases" |
| `build-buildx-package.yml` | "Track Docker Buildx Releases" |
| `build-buildx-rpm.yml` | "Track Docker Buildx Releases" |

## Problem

These package workflows were only triggered by weekly builds, missing releases detected between weekly runs. This caused:
- CLI v29.0.2 Debian package not being built when the release was detected
- Potential missed Buildx packages when new releases are tracked

The RPM workflows for CLI and cagent already had the correct triggers.

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Future releases from tracking workflows should trigger package builds
- [ ] Manually triggered `build-cli-package.yml` for v29.0.2 should succeed