### PR TITLE
fix(ci): update cagent workflow to require Go 1.25.4

### DIFF
--- a/.github/workflows/cagent-weekly-build.yml
+++ b/.github/workflows/cagent-weekly-build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.25.4'
 
       - name: Build cagent binary
         run: |


### PR DESCRIPTION
## Summary
Fixes the cagent build failure caused by outdated Go version in the workflow.

## Problem
cagent v1.9.23 updated its `go.mod` to require Go 1.25.4:
```
go 1.25.4
```

But the workflow was still using Go 1.23, causing this build error:
```
go: go.mod requires go >= 1.25.4 (running go 1.23.12; GOTOOLCHAIN=local)
```

## Solution
Updated the workflow to use Go 1.25.4:
```yaml
- name: Set up Go
  uses: actions/setup-go@v6
  with:
    go-version: '1.25.4'
```

## Testing
- Failed run with Go 1.23: https://github.com/gounthar/docker-for-riscv64/actions/runs/19635816761
- This fix should resolve the build failure

## Follow-up
Created UpdateCLI manifest (in separate PR) to automatically track cagent's Go version requirement and update the workflow when it changes.