### PR TITLE
fix(ci): remove invalid config parameter from UpdateCLI workflow

### DIFF
--- a/.github/workflows/updatecli-cagent.yml
+++ b/.github/workflows/updatecli-cagent.yml
@@ -33,5 +33,3 @@ jobs:
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          config: '.updatecli.d/cagent-go-version.yaml'


### PR DESCRIPTION
## Summary
Fixes the UpdateCLI cagent workflow to properly execute UpdateCLI.

## Problem
The updatecli-action@v2 was receiving an invalid `config` parameter:
```
⚠️ Unexpected input(s) 'config', valid inputs are ['version', 'version-file']
```

This caused UpdateCLI to not actually process the manifest file.

## Solution
Removed the `with: config` parameter. UpdateCLI automatically processes all manifests in `.updatecli.d/` directory, so no explicit config parameter is needed.

## Testing
After merge, the workflow will:
- Automatically find and process `.updatecli.d/cagent-go-version.yaml`
- Check cagent's go.mod for Go version requirements
- Create PRs if the version changes

## Reference
- UpdateCLI Action docs: https://github.com/updatecli/updatecli-action
- Previous run (warning): https://github.com/gounthar/docker-for-riscv64/actions/runs/19636984691