### PR TITLE
fix(ci): add git checkout to cleanup workflow for tag deletion

### DIFF
--- a/.github/workflows/cleanup-old-releases.yml
+++ b/.github/workflows/cleanup-old-releases.yml
@@ -17,6 +17,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
       - name: Cleanup old dev releases
         id: cleanup
         env:


### PR DESCRIPTION
## Summary
Fixes the "Cleanup Old Development Builds" workflow that was failing when trying to delete release tags.

## Problem
The workflow was failing with:
```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The `gh release delete --cleanup-tag` command requires a git repository to delete the associated tag, but the workflow didn't checkout the repository.

## Solution
Added `actions/checkout@v6` step with `fetch-depth: 0` to checkout the repository before cleanup.

## Testing
After merge, the workflow will be able to:
- Delete old development releases (older than 1 month)
- Delete their associated git tags
- Create a report issue when releases are deleted

## Error Fixed
- Failed run: https://github.com/gounthar/docker-for-riscv64/actions/runs/19638505019

## Related
- Original workflow added in: PR #151