### PR TITLE
fix(ci): enable CGO for cagent build to support tree-sitter dependency

### DIFF
--- a/.github/workflows/cagent-weekly-build.yml
+++ b/.github/workflows/cagent-weekly-build.yml
@@ -46,6 +46,11 @@ jobs:
         with:
           go-version: '1.25.4'
 
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential
+
       - name: Build cagent binary
         run: |
           set -euo pipefail
@@ -57,8 +62,8 @@ jobs:
           echo "Building cagent version: $GIT_TAG"
           echo "Commit: $GIT_COMMIT"
 
-          # Build with version info
-          GOOS=linux GOARCH=riscv64 CGO_ENABLED=0 go build \
+          # Build with version info (CGO enabled for tree-sitter dependency)
+          GOOS=linux GOARCH=riscv64 CGO_ENABLED=1 go build \
             -ldflags "-X 'github.com/docker/cagent/pkg/version.Version=${GIT_TAG}' -X 'github.com/docker/cagent/pkg/version.Commit=${GIT_COMMIT}'" \
             -o cagent-linux-riscv64 \
             ./main.go
@@ -149,8 +154,9 @@ jobs:
 
           **Build Command:**
           \`\`\`bash
+          # Requires build-essential (gcc, g++, make) for CGO dependencies
           cd cagent
-          GOOS=linux GOARCH=riscv64 CGO_ENABLED=0 go build \\
+          GOOS=linux GOARCH=riscv64 CGO_ENABLED=1 go build \\
             -ldflags "-X 'github.com/docker/cagent/pkg/version.Version=${CAGENT_VERSION}'" \\
             -o cagent-linux-riscv64 ./main.go
           \`\`\`


### PR DESCRIPTION
## Summary
Fixes the cagent build failure by enabling CGO and installing build dependencies.

## Problem
The cagent build was failing with:
```
github.com/smacker/go-tree-sitter/golang: build constraints exclude all Go files
# github.com/smacker/go-tree-sitter
undefined: Node (multiple occurrences)
```

This occurred because `go-tree-sitter` (a transitive dependency) requires CGO to compile C bindings, but the workflow was building with `CGO_ENABLED=0`.

## Solution
- Changed `CGO_ENABLED=0` to `CGO_ENABLED=1` in the build command
- Added step to install `build-essential` package (provides gcc, g++, make)
- Updated release notes to document CGO requirement for users building from source

## Testing
- [x] Manual workflow run triggered on this branch
- [x] Workflow run: https://github.com/gounthar/docker-for-riscv64/actions/runs/19774150137
- [ ] Build completes successfully (in progress)

## Notes
The resulting binary will be dynamically linked instead of static, which is acceptable as:
- The upstream cagent Dockerfile doesn't enforce static linking
- The binary will still work on target RISC-V64 systems with standard C libraries
- This matches the upstream build approach

Closes #170