### PR TITLE
fix(ci): add buildx builder cleanup step to BuildKit workflow

### DIFF
--- a/.github/workflows/buildkit-weekly-build.yml
+++ b/.github/workflows/buildkit-weekly-build.yml
@@ -46,6 +46,25 @@ jobs:
 
           echo "Building from: $(git describe --tags --always)"
 
+      - name: Clean up buildx builders
+        run: |
+          # Clean up any unhealthy or stuck buildx builders
+          # This prevents "container is restarting" errors from previous failed builds
+          echo "Current buildx builders:"
+          docker buildx ls || true
+
+          # Remove riscv-builder if it exists (used by BuildKit's bake)
+          if docker buildx ls | grep -q "riscv-builder"; then
+            echo "Removing existing riscv-builder..."
+            docker buildx rm riscv-builder --force || true
+          fi
+
+          # Also clean up any dangling buildx containers
+          docker ps -a --filter "name=buildx_buildkit" --format "{{.ID}}" | xargs -r docker rm -f || true
+
+          echo "Buildx builders after cleanup:"
+          docker buildx ls || true
+
       - name: Build buildkit binaries
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- Add cleanup step to remove unhealthy/stuck buildx builders before building
- Prevents workflow failures when riscv-builder container is in restart loop
- Clean up dangling buildx_buildkit containers that may interfere

## Problem
The BuildKit workflow failed with:
```
ERROR: Error response from daemon: Container 8c7d66... is restarting, wait until the container is running
make: *** [Makefile:16: binaries] Error 1
```

This happens when the buildx builder container from a previous run gets stuck in a restart loop.

## Solution
Add a pre-build cleanup step that:
1. Lists current buildx builders (for debugging)
2. Removes `riscv-builder` if it exists (with `--force`)
3. Removes any dangling `buildx_buildkit` containers
4. Lists builders after cleanup (to confirm clean state)

## Test plan
- [ ] Workflow should now complete successfully
- [ ] Builder cleanup logs visible in workflow output
- [ ] Build produces working binaries and container image