### PR TITLE
fix(ci): use git clone instead of submodule for BuildKit

### DIFF
--- a/.github/workflows/buildkit-weekly-build.yml
+++ b/.github/workflows/buildkit-weekly-build.yml
@@ -27,13 +27,16 @@ jobs:
           submodules: false
           fetch-depth: 0
 
-      - name: Checkout buildkit submodule only
+      - name: Clone BuildKit repository
         run: |
           set -euo pipefail
           BUILDKIT_REF="${{ github.event.inputs.buildkit_ref || 'master' }}"
 
-          # Only init and update the buildkit submodule (skip moby, cli, compose, cagent)
-          git submodule update --init --depth 1 buildkit
+          # Clone BuildKit directly instead of using submodule
+          # This ensures proper .git directory for buildx bake (BUILDKIT_CONTEXT_KEEP_GIT_DIR=1)
+          # Submodules use gitlinks (.git file) which breaks git operations in Docker context
+          rm -rf buildkit
+          git clone https://github.com/moby/buildkit.git
 
           cd buildkit
           git fetch origin --tags


### PR DESCRIPTION
## Summary
- Use `git clone` instead of submodule for BuildKit checkout
- Fixes version extraction failure in Docker build context

## Problem
The BuildKit build failed with:
```
ERROR [buildkit-version 1/1] RUN --mount=target=. <<'EOT' (git rev-parse HEAD...
Failed to get git revision, make sure --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 is set
```

BuildKit's `docker-bake.hcl` uses `BUILDKIT_CONTEXT_KEEP_GIT_DIR=1` to include the `.git` directory in the build context for version embedding.

However, git submodules use **gitlinks** (a `.git` file pointing to `../.git/modules/buildkit`) instead of a proper `.git` directory. When Docker transfers the build context, this link breaks.

## Solution
Clone BuildKit directly using `git clone https://github.com/moby/buildkit.git`, which creates a proper `.git` directory that works with buildx bake.

This is the same approach used by `buildx-weekly-build.yml`.

## Test plan
- [ ] Workflow completes the "Build buildkit binaries" step
- [ ] Version info is properly embedded in binaries
- [ ] Release is created successfully