### PR TITLE
fix(ci): build container from repo root to avoid .dockerignore

### DIFF
--- a/.github/workflows/buildkit-weekly-build.yml
+++ b/.github/workflows/buildkit-weekly-build.yml
@@ -109,8 +109,8 @@ jobs:
           DATE=$(date +%Y%m%d)
           BUILDKIT_REF="${{ github.event.inputs.buildkit_ref || 'master' }}"
 
-          cd buildkit
-          BUILDKIT_VERSION=$(git describe --tags --always)
+          # Get version from buildkit subdir
+          BUILDKIT_VERSION=$(cd buildkit && git describe --tags --always)
 
           # Determine image tag based on ref type
           if [[ "$BUILDKIT_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
@@ -123,17 +123,18 @@ jobs:
 
           echo "Building container image with tag: $IMAGE_TAG"
 
-          # Build using the Dockerfile.riscv64 we created
+          # Build from repo root to avoid buildkit's .dockerignore excluding bin/
+          # The Dockerfile expects binaries at buildkit/bin/build/
           docker build \
             --build-arg BUILDKIT_VERSION="$BUILDKIT_VERSION" \
-            -f ../Dockerfile.buildkit-riscv64 \
+            -f Dockerfile.buildkit-riscv64 \
             -t buildkit:$IMAGE_TAG \
             -t buildkit:latest \
             .
 
           # Save image metadata
-          echo "$IMAGE_TAG" > ../release-buildkit-$DATE/IMAGE_TAG.txt
-          docker inspect buildkit:$IMAGE_TAG > ../release-buildkit-$DATE/IMAGE_INSPECT.json
+          echo "$IMAGE_TAG" > release-buildkit-$DATE/IMAGE_TAG.txt
+          docker inspect buildkit:$IMAGE_TAG > release-buildkit-$DATE/IMAGE_INSPECT.json
 
       - name: Test BuildKit container
         run: |

--- a/Dockerfile.buildkit-riscv64
+++ b/Dockerfile.buildkit-riscv64
@@ -31,9 +31,10 @@ RUN apt-get update && \
 # Create buildkit directories
 RUN mkdir -p /var/lib/buildkit /etc/buildkit
 
-# Copy buildkit binaries (built by workflow - buildx outputs to bin/build/)
+# Copy buildkit binaries (built by workflow - buildx outputs to buildkit/bin/build/)
+# Build context is repo root to avoid buildkit's .dockerignore excluding bin/
 # Using --chmod to set executable permissions in a single layer
-COPY --chmod=0755 bin/build/buildkitd bin/build/buildctl /usr/bin/
+COPY --chmod=0755 buildkit/bin/build/buildkitd buildkit/bin/build/buildctl /usr/bin/
 
 # Verify binaries work (will fail build if binaries are broken)
 RUN buildkitd --version && buildctl --version


### PR DESCRIPTION
## Summary
- Build Docker container from repo root instead of buildkit directory
- Update Dockerfile paths to match new build context

## Problem
The container image build failed with:
```
=> ERROR [4/6] COPY --chmod=0755 bin/build/buildkitd bin/build/buildctl /usr/bin/
=> => transferring context: 2B
```

Only **2 bytes** were transferred to the build context because the buildkit repo's `.dockerignore` excludes `bin/`.

## Root Cause
The buildkit repository has a `.dockerignore` file that excludes:
```
bin/
_output/
```

When building with context from `buildkit/`, the freshly compiled binaries in `bin/build/` are excluded.

## Solution
Build from the repo root instead:
- **Dockerfile**: Update paths from `bin/build/*` to `buildkit/bin/build/*`
- **Workflow**: Build from `.` (repo root) instead of `cd buildkit && docker build .`

This avoids the buildkit `.dockerignore` and includes the binaries in the build context.

## Test plan
- [ ] Container image build step completes successfully
- [ ] Binaries are correctly copied into the image
- [ ] Container test passes
- [ ] Image pushed to GHCR
- [ ] Release created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified build workflow and artifact path handling for consistency and to prevent unintended exclusions during Docker builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->