### PR TITLE
fix(buildkit): remove ip6tables package (included in iptables on Trixie)

### DIFF
--- a/Dockerfile.buildkit-riscv64
+++ b/Dockerfile.buildkit-riscv64
@@ -10,7 +10,7 @@ ARG BUILDKIT_VERSION=unknown
 
 # Install runtime dependencies
 # fuse-overlayfs: Rootless overlay filesystem support
-# iptables/ip6tables: Network management for buildkit networking
+# iptables: Network management for buildkit networking (includes ip6tables in Trixie)
 # git: Git operations in builds
 # openssh-client: SSH operations for git+ssh://
 # pigz: Parallel gzip for faster compression
@@ -20,7 +20,6 @@ RUN apt-get update && \
         ca-certificates \
         fuse-overlayfs \
         iptables \
-        ip6tables \
         git \
         openssh-client \
         pigz \


### PR DESCRIPTION
## Summary

- Remove `ip6tables` from Dockerfile.buildkit-riscv64 package list
- In Debian Trixie, ip6tables is included in the `iptables` package

## Problem

The BuildKit workflow failed at the "Build BuildKit container image" step with:
```
E: Unable to locate package ip6tables
```

## Root Cause

Debian Trixie consolidated `ip6tables` into the `iptables` package. The separate `ip6tables` package no longer exists.

## Solution

Remove `ip6tables` from the apt-get install list. The `iptables` package provides both iptables and ip6tables commands.

## Testing

- Workflow should now successfully build the container image
- The iptables package in Trixie includes: `iptables`, `ip6tables`, `iptables-restore`, `ip6tables-restore`, etc.

## Related

- Follows PRs #214, #215, #216 fixing BuildKit workflow issues
- Part of BuildKit RISC-V64 implementation (#211, #212, #213)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized runtime dependencies by consolidating package requirements for improved build efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->