### PR TITLE
fix(debian): skip dh_dwz for statically linked Go binaries

### DIFF
--- a/debian-buildkit/rules
+++ b/debian-buildkit/rules
@@ -16,3 +16,7 @@ override_dh_auto_test:
 override_dh_shlibdeps:
 	# Skip shared library dependencies check - statically linked
 	@echo "Skipping shlibdeps - statically linked binaries"
+
+override_dh_dwz:
+	# Skip DWARF compression - Go binaries don't have compatible debug info
+	@echo "Skipping dwz - not applicable to Go binaries"


### PR DESCRIPTION
## Summary
- Skip DWARF compression (dh_dwz) step for BuildKit Debian package

## Problem
The `dh_dwz` tool fails on Go binaries as they don't have compatible DWARF debug info sections, causing the Debian package build to fail:

```
dh_dwz: error: dwz -mdebian/buildkit/usr/lib/debug/.dwz/riscv64-linux-gnu/buildkit.debug ... returned exit code 1
```

## Solution
Add `override_dh_dwz` to debian-buildkit/rules to skip this step, similar to how `dh_shlibdeps` is already skipped for statically linked binaries.

## Test plan
- [ ] Re-run Build BuildKit Debian Package workflow
- [ ] Verify package builds successfully
- [ ] Verify package uploads to release