### PR TITLE
fix(ci): allow dev versions in BuildKit Debian changelog

### DIFF
--- a/.github/workflows/build-buildkit-package.yml
+++ b/.github/workflows/build-buildkit-package.yml
@@ -166,10 +166,13 @@ jobs:
           export DEBFULLNAME="GitHub Actions"
 
           # Copy packaging and update changelog with dch
+          # Use -b flag to allow dev versions (0.0.YYYYMMDD) that may be lower
+          # than official versions (0.17.x) already in changelog
           cp -r debian-buildkit debian
           cd debian
           dch --check-dirname-level 0 \
               --force-distribution \
+              --force-bad-version \
               --newversion "${VERSION}-riscv64-1" \
               --distribution trixie \
               "RISC-V64 prebuilt BuildKit ${VERSION}"


### PR DESCRIPTION
## Summary
Add `--force-bad-version` flag to dch to allow dev versions that may be numerically lower than official versions.

## Problem
When building dev releases (e.g., `buildkit-v20251209-dev` → version `0.0.20251209`) after an official release (e.g., `0.26.2`), dch rejects the version:

```
dch: fatal error: New version specified (0.0.20251209-riscv64-1) is less than
the current version number (0.17.3-riscv64-1)!
```

## Solution
Add `--force-bad-version` flag to allow non-sequential versions, enabling both official and dev builds.

## Test plan
- [ ] Merge and trigger dev build: `buildkit-v20251209-dev`
- [ ] Verify package builds successfully