### PR TITLE
fix(ci): auto-detect latest official BuildKit release when triggered manually

### DIFF
--- a/.github/workflows/build-buildkit-package.yml
+++ b/.github/workflows/build-buildkit-package.yml
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'BuildKit release tag'
-        required: true
-        default: 'buildkit-v20251209-dev'
+        description: 'BuildKit release tag (leave empty to auto-detect latest official)'
+        required: false
+        default: ''
 
 permissions:
   contents: write
@@ -90,11 +90,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          # Get release tag from workflow_run or manual input
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            RELEASE_TAG="${{ github.event.inputs.release_tag }}"
+          # Get release tag from manual input or auto-detect
+          INPUT_TAG="${{ github.event.inputs.release_tag }}"
+          if [ -n "$INPUT_TAG" ]; then
+            RELEASE_TAG="$INPUT_TAG"
+            echo "Using manually specified release: $RELEASE_TAG"
           else
             # Find the latest OFFICIAL BuildKit release (skip dev builds)
+            echo "Auto-detecting latest official BuildKit release..."
             RELEASE_TAG=$(gh release list --repo gounthar/docker-for-riscv64 --limit 20 | \
                           awk -F'\t' '$3 ~ /^buildkit-v[0-9]+\.[0-9]+\.[0-9]+/ {print $3; exit}')
           fi

--- a/.github/workflows/build-buildkit-rpm.yml
+++ b/.github/workflows/build-buildkit-rpm.yml
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'BuildKit release tag to build package from'
-        required: true
-        default: 'buildkit-v20251209-dev'
+        description: 'BuildKit release tag (leave empty to auto-detect latest official)'
+        required: false
+        default: ''
 
 permissions:
   contents: write
@@ -31,12 +31,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Skip check for manual dispatch
+          # Handle manual dispatch with optional release tag
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "Manual dispatch - proceeding with build"
-            echo "has-new-release=true" >> $GITHUB_OUTPUT
-            echo "release-tag=${{ github.event.inputs.release_tag }}" >> $GITHUB_OUTPUT
-            exit 0
+            INPUT_TAG="${{ github.event.inputs.release_tag }}"
+            if [ -n "$INPUT_TAG" ]; then
+              echo "Manual dispatch with specified release: $INPUT_TAG"
+              echo "has-new-release=true" >> $GITHUB_OUTPUT
+              echo "release-tag=$INPUT_TAG" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+            echo "Manual dispatch - auto-detecting latest official release..."
+            # Fall through to auto-detection below
           fi
 
           # Find the latest BuildKit OFFICIAL release (skip dev/weekly builds)


### PR DESCRIPTION
## Summary
Remove hardcoded dev build default from workflow inputs. When triggered manually without specifying a release tag, workflows now auto-detect the latest official release.

## Problem
The default `release_tag` input was set to `buildkit-v20251209-dev`, causing manual triggers to always select the dev build instead of the official release.

## Solution
- Change input to `required: false` with empty default
- Update logic to auto-detect latest official release (vX.Y.Z pattern) when input is empty
- If input is provided, use it directly

## Test plan
- [ ] Trigger workflow without specifying release_tag
- [ ] Verify it auto-detects `buildkit-v0.26.2-riscv64`