### PR TITLE
fix(buildkit): add runc to container image for OCI worker support

### DIFF
--- a/Dockerfile.buildkit-riscv64
+++ b/Dockerfile.buildkit-riscv64
@@ -9,15 +9,18 @@ FROM debian:trixie-slim
 ARG BUILDKIT_VERSION=unknown
 
 # Install runtime dependencies
+# runc: OCI runtime for BuildKit worker
 # fuse-overlayfs: Rootless overlay filesystem support
 # iptables: Network management for buildkit networking (includes ip6tables in Trixie)
 # git: Git operations in builds
 # openssh-client: SSH operations for git+ssh://
 # pigz: Parallel gzip for faster compression
 # xz-utils: XZ compression support
+# tini: Init process for proper signal handling
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
+        runc \
         fuse-overlayfs \
         iptables \
         git \


### PR DESCRIPTION
## Problem

BuildKit container crashes in restart loop with error:
```
buildkitd: no worker found, rebuild the buildkit daemon?
skipping oci worker, as runc does not exist
```

When used with Docker Buildx, the container fails to bootstrap because BuildKit requires at least one worker backend to function.

## Root Cause

The `Dockerfile.buildkit-riscv64` was missing **runc**, which is required for BuildKit's OCI worker backend.

## Solution

Added `runc` package to the Debian package installation list in the Dockerfile.

## Changes

- **Dockerfile.buildkit-riscv64**: Add `runc` to apt install list with documentation comment

## Testing

After merge, the workflow will build a new container image with runc included. Test with:

```bash
docker pull ghcr.io/gounthar/buildkit-riscv64:latest
docker buildx create --name buildkit-riscv \
  --driver docker-container \
  --driver-opt image=ghcr.io/gounthar/buildkit-riscv64:latest --use
docker buildx inspect --bootstrap  # Should succeed
```

## Related

- PR #227: Fixed ENTRYPOINT/CMD for Buildx argument passing
- This PR completes the BuildKit Docker Buildx integration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime dependencies and enhanced documentation for RISC-V 64-bit architecture support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->