### PR TITLE
fix(buildkit): use runc from docker-for-riscv64 APT repository

### DIFF
--- a/Dockerfile.buildkit-riscv64
+++ b/Dockerfile.buildkit-riscv64
@@ -8,8 +8,16 @@ FROM debian:trixie-slim
 # BuildKit version (passed as build arg)
 ARG BUILDKIT_VERSION=unknown
 
+# Add docker-for-riscv64 APT repository for runc package
+# This ensures we use the same runc version as Docker Engine builds
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
+    curl -fsSL https://github.com/gounthar/docker-for-riscv64/releases/download/gpg-key/public-key.asc | gpg --dearmor -o /usr/share/keyrings/docker-riscv64-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/docker-riscv64-archive-keyring.gpg] https://gounthar.github.io/docker-for-riscv64 trixie main" > /etc/apt/sources.list.d/docker-riscv64.list && \
+    rm -rf /var/lib/apt/lists/*
+
 # Install runtime dependencies
-# runc: OCI runtime for BuildKit worker
+# runc: OCI runtime for BuildKit worker (from docker-for-riscv64 repository v1.3.0)
 # fuse-overlayfs: Rootless overlay filesystem support
 # iptables: Network management for buildkit networking (includes ip6tables in Trixie)
 # git: Git operations in builds
@@ -19,7 +27,6 @@ ARG BUILDKIT_VERSION=unknown
 # tini: Init process for proper signal handling
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        ca-certificates \
         runc \
         fuse-overlayfs \
         iptables \


### PR DESCRIPTION
## Problem

Currently, the BuildKit container installs runc from Debian's repository. This creates version inconsistency - Docker Engine uses our runc v1.3.0, but BuildKit would use Debian's runc.

## Solution

Install runc from our own APT repository (`https://gounthar.github.io/docker-for-riscv64`) to ensure version consistency across all components.

## Changes

**Dockerfile.buildkit-riscv64:**
- Add docker-for-riscv64 APT repository with GPG key verification
- Install runc v1.3.0 from our repository instead of Debian's
- Add `curl` and `gnupg` dependencies for repository setup

## Benefits

1. **Version Consistency**: Same runc v1.3.0 across Docker Engine and BuildKit
2. **Controlled Updates**: We manage when runc gets updated
3. **Component Compatibility**: Ensures all docker-for-riscv64 components work together
4. **User Experience**: Consistent runtime behavior across all tools

## Testing

After merge, the workflow will build a new container image. Test with:

```bash
docker pull ghcr.io/gounthar/buildkit-riscv64:latest

# Verify runc version inside container
docker run --rm ghcr.io/gounthar/buildkit-riscv64:latest runc --version
# Expected: runc version 1.3.0

# Test with Docker Buildx
docker buildx create --name test-builder \
  --driver docker-container \
  --driver-opt image=ghcr.io/gounthar/buildkit-riscv64:latest --use
docker buildx inspect --bootstrap
```

## Related

- PR #228: Added runc to BuildKit container (from Debian)
- This PR: Use our own runc package for consistency
- Complements PR #227: ENTRYPOINT/CMD fix for Buildx