### PR TITLE
fix(ci): add 30s timeout to BuildKit container test

### DIFF
--- a/.github/workflows/buildkit-weekly-build.yml
+++ b/.github/workflows/buildkit-weekly-build.yml
@@ -147,7 +147,8 @@ jobs:
           # Test that container starts and reports version
           echo "Testing BuildKit container..."
           # Intentional: Allow failure as buildkitd may require privileges to report version
-          docker run --rm buildkit:latest buildkitd --version || echo "Note: buildkitd --version requires privileges, container exists and is runnable"
+          # Add timeout to prevent hanging if container gets stuck initializing workers
+          timeout 30s docker run --rm buildkit:latest buildkitd --version || echo "Note: buildkitd --version may require privileges or timed out (30s), container exists and is runnable"
 
           # Save test results
           echo "Container test completed at $(date)" > release-buildkit-$DATE/TEST_RESULTS.txt


### PR DESCRIPTION
## Problem

The BuildKit container test step can hang indefinitely if buildkitd gets stuck initializing workers:

```bash
docker run --rm buildkit:latest buildkitd --version
```

When buildkitd starts, it attempts to initialize workers (OCI, containerd). If there are issues with runc or other dependencies, the container may hang instead of failing cleanly. The workflow then waits forever.

## Solution

Add `timeout 30s` to the docker run command:

```bash
timeout 30s docker run --rm buildkit:latest buildkitd --version || echo "..."
```

After 30 seconds, timeout kills the container and the `||` fallback triggers, allowing the workflow to continue.

## Why 30 seconds?

- Version check should complete in <5 seconds normally
- 30s is generous headroom for slow systems
- Long enough to detect actual hangs vs slow execution
- Still fails fast enough to not waste CI time

## Testing Strategy

**Currently**: Workflow 20100911136 is running with the old code (no timeout). Observing whether it:
1. ✅ Completes successfully → Merge this PR for future protection
2. ❌ Gets stuck on test step → Merge this PR immediately and restart

## Related

- PR #228: Added runc support
- PR #229: Use our runc v1.3.0 package
- This PR: Prevent test hangs even if runc has issues