### PR TITLE
fix(buildkit): correct GPG key filename in APT repository setup

### DIFF
--- a/Dockerfile.buildkit-riscv64
+++ b/Dockerfile.buildkit-riscv64
@@ -12,7 +12,7 @@ ARG BUILDKIT_VERSION=unknown
 # This ensures we use the same runc version as Docker Engine builds
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
-    curl -fsSL https://github.com/gounthar/docker-for-riscv64/releases/download/gpg-key/public-key.asc | gpg --dearmor -o /usr/share/keyrings/docker-riscv64-archive-keyring.gpg && \
+    curl -fsSL https://github.com/gounthar/docker-for-riscv64/releases/download/gpg-key/gpg-public-key.asc | gpg --dearmor -o /usr/share/keyrings/docker-riscv64-archive-keyring.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/docker-riscv64-archive-keyring.gpg] https://gounthar.github.io/docker-for-riscv64 trixie main" > /etc/apt/sources.list.d/docker-riscv64.list && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Critical Bug Fix

The GPG key filename was **incorrect**, causing all BuildKit builds to fail.

## Problem

Dockerfile line 15 used:
```bash
curl -fsSL .../gpg-key/public-key.asc
```

But the actual filename is:
```bash
gpg-public-key.asc
```

Result: **curl returned 404**, Docker build failed.

## Impact

- Workflow 20100911136 FAILED ❌
- PR #229 changes couldn't be tested
- No BuildKit image with our runc package

## Fix

Changed URL from:
```
public-key.asc → gpg-public-key.asc
```

## Testing

```bash
# Verify URL works now
curl -fsSL https://github.com/gounthar/docker-for-riscv64/releases/download/gpg-key/gpg-public-key.asc | head -5
```

## Next Steps

After merge:
1. Trigger new BuildKit workflow
2. Should complete successfully with our runc v1.3.0
3. Test Docker Buildx integration