### PR TITLE
feat(buildkit): add APT installation option to release notes

### DIFF
--- a/.github/workflows/buildkit-weekly-build.yml
+++ b/.github/workflows/buildkit-weekly-build.yml
@@ -273,9 +273,9 @@ jobs:
           **Option 3: Install from APT Repository (Standalone Binaries)**
           \`\`\`bash
           # Add docker-for-riscv64 APT repository (if not already configured)
-          curl -fsSL https://github.com/gounthar/docker-for-riscv64/releases/download/gpg-key/gpg-public-key.asc | \\
-            sudo gpg --dearmor -o /usr/share/keyrings/docker-riscv64-archive-keyring.gpg
-          echo "deb [signed-by=/usr/share/keyrings/docker-riscv64-archive-keyring.gpg] https://gounthar.github.io/docker-for-riscv64 trixie main" | \\
+          wget -qO- https://github.com/gounthar/docker-for-riscv64/releases/download/gpg-key/docker-riscv64.gpg | \\
+            sudo tee /usr/share/keyrings/docker-riscv64.gpg > /dev/null
+          echo "deb [arch=riscv64 signed-by=/usr/share/keyrings/docker-riscv64.gpg] https://gounthar.github.io/docker-for-riscv64 trixie main" | \\
             sudo tee /etc/apt/sources.list.d/docker-riscv64.list
 
           # Install BuildKit binaries


### PR DESCRIPTION
## Summary

Add Option 3 to BuildKit release notes for APT repository installation.

## Changes

- Add complete APT setup instructions (GPG key, repository, install)
- Include verification commands (`buildkitd --version`, `buildctl --version`)
- Add prominent note explaining APT installs standalone binaries only
- Clarify that Docker Buildx requires the container image (Option 1)

## Benefits

- Easier installation for users with APT repo already configured
- Clear distinction between standalone use vs Buildx integration
- Complete setup instructions for new users
- Reduces confusion about installation options

## Testing

Release notes will be generated in the next BuildKit build workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an APT repository installation option for BuildKit on RISC‑V64, including steps to configure the repo, install via apt, and verify installed binaries.
  * Clarified this method delivers host binaries and that the container image option is still required for Docker Buildx integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->