### PR TITLE
fix(apt-repo): increase release list limit from 50 to 100

### DIFF
--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -48,7 +48,7 @@ jobs:
           else
             # Find the latest -riscv64 release using JSON output
             RELEASE_TAG=$(gh release list --repo gounthar/docker-for-riscv64 \
-                          --limit 50 --json tagName | \
+                          --limit 100 --json tagName | \
                           jq -r '.[] | select(.tagName |
                             test("^(compose-|cli-|buildx-|buildkit-|cagent-)?v[0-9]+\\.[0-9]+\\.[0-9]+-riscv64$")) |
                             .tagName' | \
@@ -90,7 +90,7 @@ jobs:
 
           # Find latest Engine release (docker.io, containerd, runc)
           DOCKER_RELEASE=$(gh release list --repo gounthar/docker-for-riscv64 \
-                           --limit 50 --json tagName | \
+                           --limit 100 --json tagName | \
                            jq -r '.[] | select(.tagName |
                              test("^v[0-9]+\\.[0-9]+\\.[0-9]+-riscv64$")) | .tagName' | \
                            head -1)
@@ -98,7 +98,7 @@ jobs:
 
           # Find latest CLI release
           CLI_RELEASE=$(gh release list --repo gounthar/docker-for-riscv64 \
-                        --limit 50 --json tagName | \
+                        --limit 100 --json tagName | \
                         jq -r '.[] | select(.tagName |
                           test("^cli-v[0-9]+\\.[0-9]+\\.[0-9]+-riscv64$")) | .tagName' | \
                         head -1)
@@ -106,7 +106,7 @@ jobs:
 
           # Find latest Compose release
           COMPOSE_RELEASE=$(gh release list --repo gounthar/docker-for-riscv64 \
-                            --limit 50 --json tagName | \
+                            --limit 100 --json tagName | \
                             jq -r '.[] | select(.tagName |
                               test("^compose-v[0-9]+\\.[0-9]+\\.[0-9]+-riscv64$")) | .tagName' | \
                             head -1)
@@ -114,7 +114,7 @@ jobs:
 
           # Find latest Buildx release
           BUILDX_RELEASE=$(gh release list --repo gounthar/docker-for-riscv64 \
-                           --limit 50 --json tagName | \
+                           --limit 100 --json tagName | \
                            jq -r '.[] | select(.tagName |
                              test("^buildx-v[0-9]+\\.[0-9]+\\.[0-9]+-riscv64$")) | .tagName' | \
                            head -1)
@@ -122,7 +122,7 @@ jobs:
 
           # Find latest cagent release
           CAGENT_RELEASE=$(gh release list --repo gounthar/docker-for-riscv64 \
-                           --limit 50 --json tagName | \
+                           --limit 100 --json tagName | \
                            jq -r '.[] | select(.tagName |
                              test("^cagent-v[0-9]+\\.[0-9]+\\.[0-9]+-riscv64$")) | .tagName' | \
                            head -1)
@@ -130,7 +130,7 @@ jobs:
 
           # Find latest BuildKit release
           BUILDKIT_RELEASE=$(gh release list --repo gounthar/docker-for-riscv64 \
-                           --limit 50 --json tagName | \
+                           --limit 100 --json tagName | \
                            jq -r '.[] | select(.tagName |
                              test("^buildkit-v[0-9]+\\.[0-9]+\\.[0-9]+-riscv64$")) | .tagName' | \
                            head -1)


### PR DESCRIPTION
## Summary
- Increases `--limit` from 50 to 100 in update-apt-repo.yml

## Problem
Compose (`compose-v2.40.1-riscv64`) and Buildx (`buildx-v0.30.1-riscv64`) releases were at positions 55 and 85 in the release list, outside the `--limit 50` window. This caused the APT repository update workflow to miss these packages.

## Fix
Increases limit to 100 to ensure all official releases are found, even when frequent cagent and dev releases push them further down the list.

## Test plan
- [x] Verify workflow syntax is valid
- [ ] Re-trigger update-apt-repo.yml after merge
- [ ] Verify docker-compose-plugin and docker-buildx-plugin appear in APT repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved release discovery process by expanding the scan scope to include more releases in automated repository updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->