### PR TITLE
fix(ci): add Track BuildKit Releases trigger to package workflows

### DIFF
--- a/.github/workflows/build-buildkit-package.yml
+++ b/.github/workflows/build-buildkit-package.yml
@@ -2,7 +2,7 @@ name: Build BuildKit Debian Package
 
 on:
   workflow_run:
-    workflows: ["Weekly BuildKit RISC-V64 Build"]
+    workflows: ["Weekly BuildKit RISC-V64 Build", "Track BuildKit Releases"]
     types: [completed]
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/build-buildkit-rpm.yml
+++ b/.github/workflows/build-buildkit-rpm.yml
@@ -2,7 +2,7 @@ name: Build BuildKit RPM Package
 
 on:
   workflow_run:
-    workflows: ["Weekly BuildKit RISC-V64 Build"]
+    workflows: ["Weekly BuildKit RISC-V64 Build", "Track BuildKit Releases"]
     types: [completed]
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Add "Track BuildKit Releases" as a workflow_run trigger to both `build-buildkit-package.yml` and `build-buildkit-rpm.yml`
- Aligns with the working cagent workflow pattern

## Problem
BuildKit v0.26.3 was built today but no Debian/RPM packages were created. Investigation revealed:

1. `Track BuildKit Releases` detects new upstream release → triggers `buildkit-weekly-build.yml` via `workflow_dispatch`
2. `buildkit-weekly-build.yml` completes successfully → creates release
3. `build-buildkit-package.yml` **never triggers** because `workflow_run` doesn't chain through `workflow_dispatch` calls

The cagent workflows work correctly because they listen to **both** the weekly build AND the track releases workflow.

## Test plan
- [ ] Merge this PR
- [ ] Manually trigger `Track BuildKit Releases` workflow
- [ ] Verify package workflows are triggered when track workflow completes
- [ ] Alternatively, manually trigger package builds for v0.26.3 now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated build workflows to include additional release tracking integration points in the deployment pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->