### PR TITLE
debug(ci): add verbose logging to RPM build dependencies step

### DIFF
--- a/.github/workflows/build-buildkit-rpm.yml
+++ b/.github/workflows/build-buildkit-rpm.yml
@@ -73,12 +73,31 @@ jobs:
       - name: Install build dependencies
         if: steps.release.outputs.has-new-release == 'true'
         run: |
+          set -x
+          echo "=== Starting Install build dependencies ==="
+          echo "Current user: $(whoami)"
+          echo "Current directory: $(pwd)"
+          echo "Date: $(date)"
+
           if [ -f /etc/fedora-release ]; then
+            echo "Detected Fedora"
             sudo dnf install -y rpm-build rpmdevtools rpmlint
           elif [ -f /etc/debian_version ]; then
-            sudo apt-get update
-            sudo apt-get install -y rpm rpmlint
+            echo "Detected Debian/Ubuntu"
+            echo "Checking for apt locks..."
+            sudo lsof /var/lib/dpkg/lock-frontend 2>/dev/null || echo "No lock on lock-frontend"
+            sudo lsof /var/lib/apt/lists/lock 2>/dev/null || echo "No lock on apt lists"
+            echo "Running apt-get update..."
+            sudo apt-get update -y
+            echo "apt-get update completed"
+            echo "Running apt-get install..."
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y rpm rpmlint
+            echo "apt-get install completed"
+          else
+            echo "Unknown distribution"
+            cat /etc/os-release || true
           fi
+          echo "=== Install build dependencies finished ==="
 
       - name: Set up RPM build tree
         if: steps.release.outputs.has-new-release == 'true'


### PR DESCRIPTION
## Summary
- Add verbose logging to diagnose stuck RPM build

## Changes
- `set -x` for bash tracing
- Check for apt locks before running apt commands
- Echo statements before/after each command
- Use `DEBIAN_FRONTEND=noninteractive`

## Test plan
- [ ] Merge and trigger `build-buildkit-rpm.yml`
- [ ] Check logs to see where it hangs
- [ ] Remove debug logging once issue is identified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build system stability with improved package installation logging and error handling on Debian-based systems.
  * Added distribution-specific configuration detection for more robust dependency installation across different Linux distributions.
  * Improved build process visibility with verbose output and comprehensive status tracking for better debugging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->