### PR TITLE
feat(ci): add runner diagnostics workflow

### DIFF
--- a/.github/workflows/runner-diagnostics.yml
+++ b/.github/workflows/runner-diagnostics.yml
@@ -70,9 +70,12 @@ jobs:
       - name: Test apt commands
         run: |
           echo "=== Testing apt-get update ==="
+          set +e
           time sudo apt-get update -y 2>&1 | tail -20
+          APT_EXIT_CODE=${PIPESTATUS[0]}
+          set -e
           echo ""
-          echo "apt-get update exit code: $?"
+          echo "apt-get update exit code: $APT_EXIT_CODE"
           echo ""
 
       - name: Check sudo configuration


### PR DESCRIPTION
## Summary
- Add workflow to diagnose differences between self-hosted RISC-V runners

## Background
The RPM build was stuck on one runner but worked on the other. This workflow helps identify what's different between them.

## Diagnostics collected
- Runner identification (name, hostname, IP)
- OS information and kernel version
- Disk space and memory
- APT lock status and running processes
- Installed packages (especially RPM build tools)
- Sudo configuration
- Network connectivity
- Environment variables

## Usage
After merging, run manually via Actions tab. Uses matrix strategy to run on both runners simultaneously for easy comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a diagnostic workflow for self-hosted riscv64 infrastructure to gather comprehensive system information for monitoring and troubleshooting: runner identity, OS and kernel details, disk and memory usage, package manager and build-tool status, network connectivity checks, sudo/permissions info, environment variables, and workspace contents.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->