### PR TITLE
cleanup(ci): remove debug logging from RPM build workflow

### DIFF
--- a/.github/workflows/build-buildkit-rpm.yml
+++ b/.github/workflows/build-buildkit-rpm.yml
@@ -73,31 +73,12 @@ jobs:
       - name: Install build dependencies
         if: steps.release.outputs.has-new-release == 'true'
         run: |
-          set -x
-          echo "=== Starting Install build dependencies ==="
-          echo "Current user: $(whoami)"
-          echo "Current directory: $(pwd)"
-          echo "Date: $(date)"
-
           if [ -f /etc/fedora-release ]; then
-            echo "Detected Fedora"
             sudo dnf install -y rpm-build rpmdevtools rpmlint
           elif [ -f /etc/debian_version ]; then
-            echo "Detected Debian/Ubuntu"
-            echo "Checking for apt locks..."
-            sudo lsof /var/lib/dpkg/lock-frontend 2>/dev/null || echo "No lock on lock-frontend"
-            sudo lsof /var/lib/apt/lists/lock 2>/dev/null || echo "No lock on apt lists"
-            echo "Running apt-get update..."
-            sudo apt-get update -y
-            echo "apt-get update completed"
-            echo "Running apt-get install..."
-            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y rpm rpmlint
-            echo "apt-get install completed"
-          else
-            echo "Unknown distribution"
-            cat /etc/os-release || true
+            sudo apt-get update
+            sudo apt-get install -y rpm rpmlint
           fi
-          echo "=== Install build dependencies finished ==="
 
       - name: Set up RPM build tree
         if: steps.release.outputs.has-new-release == 'true'


### PR DESCRIPTION
## Summary
- Remove verbose debug logging from RPM build workflow

## Background
Debug logging was added to diagnose runner hanging issues. Root cause identified: runner service not auto-starting after reboot on bananapif3-2.

Documentation added to ansible playbook repo: `docs/RUNNER-RELIABILITY-FIXES.md`