### PR TITLE
feat(ci): auto-close build issues when releases are published

### DIFF
--- a/.github/workflows/close-build-issues.yml
+++ b/.github/workflows/close-build-issues.yml
@@ -13,6 +13,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+
           RELEASE_TAG="${{ github.event.release.tag_name }}"
           echo "Release published: $RELEASE_TAG"
 
@@ -20,44 +22,40 @@ jobs:
           # Examples: v28.0.0-riscv64, compose-v2.40.1-riscv64, cli-v28.0.0-riscv64,
           #           tini-v0.19.0-riscv64, buildkit-v0.20.0-riscv64, cagent-v1.15.0-riscv64
 
+          # Common label for all build tracking issues
+          LABEL="build-in-progress"
+
           # Build search patterns based on release tag format
           case "$RELEASE_TAG" in
             compose-v*)
               VERSION=$(echo "$RELEASE_TAG" | sed 's/compose-\(v[0-9.]*\)-riscv64/\1/')
               SEARCH="Compose $VERSION"
-              LABEL="build-in-progress"
               ;;
             cli-v*)
               VERSION=$(echo "$RELEASE_TAG" | sed 's/cli-\(v[0-9.]*\)-riscv64/\1/')
               SEARCH="CLI $VERSION"
-              LABEL="build-in-progress"
               ;;
             tini-v*)
               VERSION=$(echo "$RELEASE_TAG" | sed 's/tini-\(v[0-9.]*\)-riscv64/\1/')
               SEARCH="tini $VERSION"
-              LABEL="build-in-progress"
               ;;
             buildkit-v*)
               VERSION=$(echo "$RELEASE_TAG" | sed 's/buildkit-\(v[0-9.]*\)-riscv64/\1/')
               SEARCH="BuildKit $VERSION"
-              LABEL="build-in-progress"
               ;;
             buildx-v*)
               VERSION=$(echo "$RELEASE_TAG" | sed 's/buildx-\(v[0-9.]*\)-riscv64/\1/')
               SEARCH="Buildx $VERSION"
-              LABEL="build-in-progress"
               ;;
             cagent-v*)
               VERSION=$(echo "$RELEASE_TAG" | sed 's/cagent-\(v[0-9.]*\)-riscv64/\1/')
               SEARCH="cagent $VERSION"
-              LABEL="build-in-progress"
               ;;
             v*)
               # Docker Engine (moby) releases: v28.0.0-riscv64
+              # Issue titles use format "Building Docker docker-vX.Y.Z for RISC-V64"
               VERSION=$(echo "$RELEASE_TAG" | sed 's/\(v[0-9.]*\)-riscv64/\1/')
-              # Match both "docker-vX.Y.Z" and just "vX.Y.Z" in issue titles
               SEARCH="docker-$VERSION"
-              LABEL="build-in-progress"
               ;;
             *)
               echo "Unknown release tag format: $RELEASE_TAG"
@@ -65,15 +63,22 @@ jobs:
               ;;
           esac
 
+          # Validate version extraction succeeded
+          if [ -z "$VERSION" ]; then
+            echo "Failed to extract version from: $RELEASE_TAG"
+            exit 1
+          fi
+
           echo "Looking for issues matching: $SEARCH"
 
           # Find and close matching issues
+          # Using || true to handle case where no issues match (jq returns empty)
           ISSUES=$(gh issue list \
             --repo "${{ github.repository }}" \
             --label "$LABEL" \
             --state open \
             --json number,title \
-            --jq ".[] | select(.title | test(\"$SEARCH\"; \"i\")) | .number")
+            --jq ".[] | select(.title | test(\"$SEARCH\"; \"i\")) | .number") || true
 
           if [ -z "$ISSUES" ]; then
             echo "No matching issues found"
@@ -82,6 +87,7 @@ jobs:
 
           echo "Found issues to close: $ISSUES"
 
+          # Close each issue (issue numbers are simple integers, safe for word splitting)
           for ISSUE in $ISSUES; do
             echo "Closing issue #$ISSUE"
             gh issue close "$ISSUE" \


### PR DESCRIPTION
## Summary

- Adds new workflow `close-build-issues.yml` that triggers on `release.published` events
- Automatically closes matching issues with the `build-in-progress` label
- Supports all component types (Docker Engine, CLI, Compose, BuildKit, Buildx, cagent, tini)

## Problem

Build tracking issues were accumulating because they were never closed after successful releases. This led to 30+ stale open issues cluttering the issue tracker.

## Solution

The new workflow:
1. Triggers when any release is published
2. Parses the release tag to determine the component and version
3. Searches for open issues with `build-in-progress` label matching that version
4. Closes them with a comment linking to the release

## Cleanup Performed

Also closed 33 stale issues that already had corresponding releases:
- 18 cagent issues
- 1 BuildKit issue
- 5 Docker CLI issues
- 9 Docker Engine issues

## Test Plan

- [x] Verify workflow syntax is valid
- [ ] Wait for next release and confirm issue is auto-closed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated issue management: Open issues tagged as build-in-progress are now automatically closed when matching releases are published, with automatic comments added to each closed issue for reference tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->