### PR TITLE
fix(ci): calculate date properly in cleanup report

### DIFF
--- a/.github/workflows/cleanup-old-releases.yml
+++ b/.github/workflows/cleanup-old-releases.yml
@@ -108,8 +108,7 @@ jobs:
           CUTOFF_DATE=$(date -d '1 month ago' +%Y-%m-%dT%H:%M:%SZ)
           echo "Closing cleanup report issues older than: $CUTOFF_DATE"
 
-          # Find old cleanup report issues
-          CLOSED_COUNT=0
+          # Find and close old cleanup report issues
           gh issue list \
             --repo "${{ github.repository }}" \
             --label "maintenance,automated" \
@@ -121,10 +120,9 @@ jobs:
             gh issue close "$ISSUE_NUM" \
               --repo "${{ github.repository }}" \
               --comment "Automatically closed: Cleanup report is older than 1 month."
-            CLOSED_COUNT=$((CLOSED_COUNT + 1))
           done
 
-          echo "Closed old cleanup report issues"
+          echo "Done closing old cleanup report issues"
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary

Two fixes for the cleanup workflow:

### 1. Fix date calculation in cleanup reports
The date was showing as literal `$(date -u +%Y-%m-%d)` instead of the actual date.

**Problem:** Heredoc used single quotes (`<< 'EOFR'`) which prevented shell command substitution.

**Solution:** Calculate date before heredoc and use unquoted delimiter.

### 2. Auto-close old cleanup report issues
Cleanup reports are informational logs that don't need to stay open forever.

**Added:** A new step that runs after creating the report:
1. Finds open issues with `maintenance,automated` labels
2. Filters for `Cleanup Report:` title prefix
3. Closes those older than 1 month with a comment

## Cleanup Performed
Closed 4 old cleanup report issues (#183, #205, #236, #250).

## Test Plan
- [x] Verify workflow syntax is valid
- [ ] Wait for next cleanup run or trigger manually to verify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release cleanup automation: reports now include explicit UTC date tracking and clearer formatting, and the workflow can automatically close outdated cleanup report issues to keep maintenance items up to date.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->