### PR TITLE
fix(ci): prevent race condition in package build triggers

### DIFF
--- a/.github/workflows/build-buildkit-package.yml
+++ b/.github/workflows/build-buildkit-package.yml
@@ -1,8 +1,9 @@
 name: Build BuildKit Debian Package
 
 on:
+  # Only trigger from Weekly Build - Track workflow completes before release exists
   workflow_run:
-    workflows: ["Weekly BuildKit RISC-V64 Build", "Track BuildKit Releases"]
+    workflows: ["Weekly BuildKit RISC-V64 Build"]
     types: [completed]
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/build-buildkit-rpm.yml
+++ b/.github/workflows/build-buildkit-rpm.yml
@@ -1,8 +1,9 @@
 name: Build BuildKit RPM Package
 
 on:
+  # Only trigger from Weekly Build - Track workflow completes before release exists
   workflow_run:
-    workflows: ["Weekly BuildKit RISC-V64 Build", "Track BuildKit Releases"]
+    workflows: ["Weekly BuildKit RISC-V64 Build"]
     types: [completed]
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/build-buildx-package.yml
+++ b/.github/workflows/build-buildx-package.yml
@@ -1,8 +1,9 @@
 name: Build Docker Buildx Debian Package
 
 on:
+  # Only trigger from Weekly Build - Track workflow completes before release exists
   workflow_run:
-    workflows: ["Weekly Docker Buildx RISC-V64 Build", "Track Docker Buildx Releases"]
+    workflows: ["Weekly Docker Buildx RISC-V64 Build"]
     types: [completed]
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/build-buildx-rpm.yml
+++ b/.github/workflows/build-buildx-rpm.yml
@@ -1,8 +1,9 @@
 name: Build Buildx RPM Package
 
 on:
+  # Only trigger from Weekly Build - Track workflow completes before release exists
   workflow_run:
-    workflows: ["Weekly Docker Buildx RISC-V64 Build", "Track Docker Buildx Releases"]
+    workflows: ["Weekly Docker Buildx RISC-V64 Build"]
     types: [completed]
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/build-cagent-package.yml
+++ b/.github/workflows/build-cagent-package.yml
@@ -1,8 +1,9 @@
 name: Build cagent Debian Package
 
 on:
+  # Only trigger from Weekly Build - Track workflow completes before release exists
   workflow_run:
-    workflows: ["Weekly cagent RISC-V64 Build", "Track cagent Releases"]
+    workflows: ["Weekly cagent RISC-V64 Build"]
     types: [completed]
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/build-cagent-rpm.yml
+++ b/.github/workflows/build-cagent-rpm.yml
@@ -1,8 +1,9 @@
 name: Build cagent RPM Package
 
 on:
+  # Only trigger from Weekly Build - Track workflow completes before release exists
   workflow_run:
-    workflows: ["Weekly cagent RISC-V64 Build", "Track cagent Releases"]
+    workflows: ["Weekly cagent RISC-V64 Build"]
     types: [completed]
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/build-cli-package.yml
+++ b/.github/workflows/build-cli-package.yml
@@ -1,8 +1,9 @@
 name: Build Docker CLI Debian Package
 
 on:
+  # Only trigger from Weekly Build - Track workflow completes before release exists
   workflow_run:
-    workflows: ["Weekly Docker CLI RISC-V64 Build", "Track Docker CLI Releases"]
+    workflows: ["Weekly Docker CLI RISC-V64 Build"]
     types: [completed]
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/build-cli-rpm.yml
+++ b/.github/workflows/build-cli-rpm.yml
@@ -1,8 +1,9 @@
 name: Build CLI RPM Package
 
 on:
+  # Only trigger from Weekly Build - Track workflow completes before release exists
   workflow_run:
-    workflows: ["Weekly Docker CLI RISC-V64 Build", "Track Docker CLI Releases"]
+    workflows: ["Weekly Docker CLI RISC-V64 Build"]
     types: [completed]
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/build-debian-package.yml
+++ b/.github/workflows/build-debian-package.yml
@@ -1,8 +1,9 @@
 name: Build Debian Package
 
 on:
+  # Only trigger from Build workflow - Track workflow completes before release exists
   workflow_run:
-    workflows: ["Build Docker RISC-V64", "Track Moby Releases"]
+    workflows: ["Build Docker RISC-V64"]
     types: [completed]
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/build-rpm-package.yml
+++ b/.github/workflows/build-rpm-package.yml
@@ -5,8 +5,9 @@ name: Build RPM Package
 # Running rpmbuild on Debian requires extensive workarounds that are fragile.
 
 'on':
+  # Only trigger from Build workflow - Track workflow completes before release exists
   workflow_run:
-    workflows: ["Build Docker RISC-V64", "Track Moby Releases"]
+    workflows: ["Build Docker RISC-V64"]
     types: [completed]
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- Remove Track workflows from package build triggers to fix race condition
- Track workflows complete before releases are created, causing package builds to skip
- Now package workflows only trigger from their respective Weekly Build workflows

**Root Cause:**

When `Track * Releases` workflows detect a new upstream release:
1. They complete immediately (~10 seconds)
2. This triggers the package build workflows via `workflow_run`
3. Package workflows check for releases but they don't exist yet
4. They find older releases that already have packages attached
5. Package builds are skipped entirely

Example timeline from cagent v1.16.0:
- 08:35:47 - Track cagent Releases completed → triggered package workflows
- 08:36:37 - Package workflow checked releases → found v1.15.8 (old)
- 08:42:29 - Release v1.16.0 created by Weekly Build → too late!

**Affected Workflows (10):**
- build-cagent-package.yml / build-cagent-rpm.yml
- build-buildkit-package.yml / build-buildkit-rpm.yml
- build-buildx-package.yml / build-buildx-rpm.yml
- build-cli-package.yml / build-cli-rpm.yml
- build-debian-package.yml / build-rpm-package.yml

## Test plan

- [ ] Merge this PR
- [ ] Manually trigger package builds for `cagent-v1.16.0-riscv64`
- [ ] Verify packages are attached to the release
- [ ] Monitor next weekly builds to confirm automatic package creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified GitHub Actions workflow triggers across multiple build pipelines to run on weekly schedules only, removing additional release-tracking triggers while maintaining manual dispatch capability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->