### PR TITLE
fix(ci): install libseccomp-dev for runc build

### DIFF
--- a/.github/workflows/docker-weekly-build.yml
+++ b/.github/workflows/docker-weekly-build.yml
@@ -146,6 +146,11 @@ jobs:
 
           ls -lh bin/
 
+      - name: Install runc build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libseccomp-dev pkg-config
+
       - name: Build runc
         run: |
           # Clone runc if not exists


### PR DESCRIPTION
## Summary
- Add installation of `libseccomp-dev` and `pkg-config` packages before building runc
- Fixes build failure in docker-weekly-build workflow

## Problem
The runc build was failing with:
```
Package libseccomp was not found in the pkg-config search path.
Package 'libseccomp', required by 'virtual:world', not found
make: *** [Makefile:109: static-bin] Error 1
```

## Solution
Install required development libraries before building runc static binary:
- `libseccomp-dev` - Seccomp library development headers
- `pkg-config` - Helper tool for library configuration

## Testing
- [ ] Workflow runs successfully on self-hosted runner
- [ ] Runc binary builds with seccomp support

## References
Fixes https://github.com/gounthar/docker-for-riscv64/actions/runs/20687231974

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build workflow to automatically install required system-level dependencies prior to container builds. This enhancement ensures all necessary libraries and tools are available during the build process, improving overall build reliability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->