### PR TITLE
fix(ci): prevent race condition in package build triggers

### DIFF
--- a/.github/workflows/cagent-weekly-build.yml
+++ b/.github/workflows/cagent-weekly-build.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   build-cagent:
@@ -190,12 +191,23 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           RELEASE_VERSION="${{ steps.create_release.outputs.release_version }}"
 
+          # Wait briefly for release assets to be fully available
+          echo "Waiting 10 seconds for release assets to become available..."
+          sleep 10
+
           echo "Triggering Debian package build for ${RELEASE_VERSION}..."
-          gh workflow run build-cagent-package.yml -f release_tag="${RELEASE_VERSION}"
+          if ! gh workflow run build-cagent-package.yml -f release_tag="${RELEASE_VERSION}"; then
+            echo "::error::Failed to trigger Debian package build"
+            exit 1
+          fi
 
           echo "Triggering RPM package build for ${RELEASE_VERSION}..."
-          gh workflow run build-cagent-rpm.yml -f release_tag="${RELEASE_VERSION}"
+          if ! gh workflow run build-cagent-rpm.yml -f release_tag="${RELEASE_VERSION}"; then
+            echo "::error::Failed to trigger RPM package build"
+            exit 1
+          fi
 
-          echo "Package builds triggered successfully"
+          echo "✓ Package builds triggered successfully"


### PR DESCRIPTION
## Summary
- Add explicit package build triggers to ensure Debian and RPM packages are always built for official cagent releases
- Fixes the issue where workflow_run triggers were unreliable for manually dispatched workflows

## Problem
The `workflow_run` trigger can be unreliable, especially for manually dispatched workflows. This caused several cagent releases to be created without their associated Debian and RPM packages:
- cagent-v1.18.6-riscv64 (manually fixed)
- cagent-v1.18.1-riscv64 (manually fixed)
- cagent-v1.15.2-riscv64 (manually fixed - RPM only)

## Solution
1. Add step ID to "Create release" step
2. Output release version to `GITHUB_OUTPUT`
3. Add new step that explicitly triggers package builds after release creation
4. Skip package builds for development builds (`-dev` suffix)

## Changes
**Modified:**
- `.github/workflows/cagent-weekly-build.yml`
  - Added `id: create_release` to the release creation step
  - Added output: `release_version` to `GITHUB_OUTPUT`
  - Added new step: "Trigger package builds for official releases"
  - Step only runs for non-dev releases using `if: !endsWith(..., '-dev')`

## Testing
- [x] Manual package builds completed successfully for v1.18.6 and v1.18.1
- [x] Both releases now have all expected assets (.deb, .rpm, binary, VERSION.txt)
- [ ] Next cagent build will automatically trigger package builds

## Future Work
Consider applying the same fix to:
- `docker-weekly-build.yml`
- `compose-weekly-build.yml`  
- `cli-weekly-build.yml`
- `tini-weekly-build.yml`

## References
- Original issue: Missing packages on https://github.com/gounthar/docker-for-riscv64/releases/tag/cagent-v1.18.6-riscv64

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release automation to compute and expose the release version for use in downstream steps and release notes.
  * Retains existing release creation flow while adding a post-release step that, for official (non -dev) releases, waits briefly for assets and triggers automated package builds with per-trigger error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->