### PR TITLE
fix(ci): automatically close tracking issues when releases are published

### DIFF
--- a/.github/workflows/cleanup-old-dev-releases.yml
+++ b/.github/workflows/cleanup-old-dev-releases.yml
@@ -10,6 +10,7 @@ on:
         description: 'Keep dev releases newer than this many days'
         required: false
         default: '30'
+        type: number
       dry_run:
         description: 'Dry run (only show what would be deleted)'
         required: false
@@ -39,6 +40,18 @@ jobs:
           # Configuration
           RETENTION_DAYS="${{ github.event.inputs.retention_days || '30' }}"
           DRY_RUN="${{ github.event.inputs.dry_run || 'false' }}"
+
+          # Validate inputs
+          if ! [[ "$RETENTION_DAYS" =~ ^[0-9]+$ ]]; then
+            echo "❌ ERROR: retention_days must be a non-negative integer, got: '$RETENTION_DAYS'" >&2
+            exit 2
+          fi
+
+          if ! [[ "$DRY_RUN" =~ ^(true|false)$ ]]; then
+            echo "❌ ERROR: dry_run must be 'true' or 'false', got: '$DRY_RUN'" >&2
+            exit 2
+          fi
+
           CUTOFF_DATE=$(date -d "${RETENTION_DAYS} days ago" +%Y%m%d)
 
           echo "🧹 Cleanup Old Development Releases"
@@ -61,10 +74,11 @@ jobs:
 
           # Get all releases
           echo "📋 Fetching releases..."
-          RELEASES=$(gh release list --limit 200 --json tagName,createdAt,isPrerelease)
+          RELEASES=$(gh release list --limit 9999 --json tagName,createdAt,isPrerelease)
 
           TOTAL_DELETED=0
           TOTAL_SKIPPED=0
+          WOULD_DELETE=0
 
           # Process each dev pattern
           for PATTERN in "${DEV_PATTERNS[@]}"; do
@@ -103,6 +117,7 @@ jobs:
 
                 if [ "$DRY_RUN" = "true" ]; then
                   echo "🔍 [DRY RUN] Would delete: $TAG (${AGE_DAYS} days old, created: $CREATED_AT)"
+                  ((WOULD_DELETE++))
                 else
                   echo "🗑️  Deleting: $TAG (${AGE_DAYS} days old, created: $CREATED_AT)"
                   if gh release delete "$TAG" --yes --cleanup-tag 2>&1; then
@@ -126,7 +141,7 @@ jobs:
           echo "======================================"
           if [ "$DRY_RUN" = "true" ]; then
             echo "Mode: DRY RUN (no releases deleted)"
-            echo "Would delete: ${TOTAL_DELETED} releases"
+            echo "Would delete: ${WOULD_DELETE} releases"
           else
             echo "Deleted: ${TOTAL_DELETED} releases"
           fi

--- a/.github/workflows/cli-weekly-build.yml
+++ b/.github/workflows/cli-weekly-build.yml
@@ -148,10 +148,11 @@ jobs:
             release-cli-$DATE/*
 
       - name: Close tracking issue
-        if: ${{ !cancelled() }}
+        if: ${{ success() }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           CLI_REF="${{ github.event.inputs.cli_ref || 'master' }}"
 
           # Only close issues for official releases (not dev builds)
@@ -167,6 +168,7 @@ jobs:
             ISSUE_NUMBER=$(gh issue list \
               --label "build-in-progress,cli-release" \
               --state open \
+              --limit 200 \
               --json number,title \
               --jq ".[] | select(.title | contains(\"${VERSION_TAG}\")) | .number" \
               | head -n1)

--- a/.github/workflows/compose-weekly-build.yml
+++ b/.github/workflows/compose-weekly-build.yml
@@ -154,24 +154,29 @@ jobs:
             release-compose-$DATE/*
 
       - name: Close tracking issue
-        if: ${{ !cancelled() }}
+        if: ${{ success() }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           COMPOSE_REF="${{ github.event.inputs.compose_ref || 'main' }}"
 
           # Only close issues for official releases (not dev builds)
-          if [[ "$COMPOSE_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
-            RELEASE_VERSION="${COMPOSE_REF}-riscv64"
+          if [[ "$COMPOSE_REF" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+            # Normalize version format to match release creation
+            CLEAN_REF="${COMPOSE_REF#v}"
+            VERSION_TAG="v${CLEAN_REF}"
+            RELEASE_VERSION="compose-${VERSION_TAG}-riscv64"
 
-            echo "Searching for tracking issue for Docker Compose ${COMPOSE_REF}..."
+            echo "Searching for tracking issue for Docker Compose ${VERSION_TAG}..."
 
             # Find the issue by label and title (if tracking workflow exists)
             ISSUE_NUMBER=$(gh issue list \
               --label "build-in-progress,compose-release" \
               --state open \
+              --limit 200 \
               --json number,title \
-              --jq ".[] | select(.title | contains(\"${COMPOSE_REF}\")) | .number" \
+              --jq ".[] | select(.title | contains(\"${VERSION_TAG}\")) | .number" \
               | head -n1)
 
             if [ -n "$ISSUE_NUMBER" ]; then
@@ -188,7 +193,7 @@ jobs:
 
               echo "Issue #${ISSUE_NUMBER} closed successfully"
             else
-              echo "No tracking issue found for ${COMPOSE_REF}"
+              echo "No tracking issue found for ${VERSION_TAG}"
             fi
           else
             echo "Skipping issue closing for development build"

--- a/.github/workflows/docker-weekly-build.yml
+++ b/.github/workflows/docker-weekly-build.yml
@@ -284,6 +284,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           MOBY_REF="${{ github.event.inputs.moby_ref || 'master' }}"
           VERSION_REGEX='${{ env.VERSION_REGEX }}'
 
@@ -298,6 +299,7 @@ jobs:
             ISSUE_NUMBER=$(gh issue list \
               --label "build-in-progress,moby-release" \
               --state open \
+              --limit 200 \
               --json number,title \
               --jq ".[] | select(.title | contains(\"${MOBY_REF}\")) | .number" \
               | head -n1)

--- a/.github/workflows/tini-weekly-build.yml
+++ b/.github/workflows/tini-weekly-build.yml
@@ -206,33 +206,35 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          TINI_REF="${{ github.event.inputs.tini_ref || github.ref_name || 'master' }}"
+          set -euo pipefail
+          TINI_REF="${{ github.event.inputs.tini_ref || 'v0.19.0' }}"
 
           # Only close issues for official releases (not dev builds)
           # Relaxed regex to accept optional leading v
           if [[ "$TINI_REF" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
             # Normalize to ensure leading v for tag
-            TINI_TAG="${TINI_REF#v}"  # Remove v if present
-            TINI_TAG="v${TINI_TAG}"   # Add v back
+            TINI_TAG="v${TINI_REF#v}"
             RELEASE_VERSION="tini-${TINI_TAG}-riscv64"
 
-            echo "Searching for tracking issue for Tini ${TINI_REF}..."
+            echo "Searching for tracking issue for Tini ${TINI_TAG}..."
 
             # Find the issue by label and title (if tracking workflow exists)
             # Note: gh issue list --label filter is OR-based
             ISSUE_NUMBER=$(gh issue list \
               --label "build-in-progress,tini-release" \
               --state open \
+              --limit 200 \
               --json number,title \
-              --jq ".[] | select(.title | contains(\"${TINI_REF}\")) | .number" \
+              --jq ".[] | select(.title | contains(\"${TINI_TAG}\")) | .number" \
               | head -n1)
 
             if [ -n "$ISSUE_NUMBER" ]; then
               echo "Found tracking issue #${ISSUE_NUMBER}"
 
               # Comment on the issue with release link
+              RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${RELEASE_VERSION}"
               gh issue comment "$ISSUE_NUMBER" \
-                --body "Build completed successfully! Release published: https://github.com/${{ github.repository }}/releases/tag/${RELEASE_VERSION}"
+                --body "Build completed successfully! Release published: ${RELEASE_URL}"
 
               # Close the issue
               gh issue close "$ISSUE_NUMBER" \
@@ -241,7 +243,7 @@ jobs:
 
               echo "Issue #${ISSUE_NUMBER} closed successfully"
             else
-              echo "No tracking issue found for ${TINI_REF}"
+              echo "No tracking issue found for ${TINI_TAG}"
             fi
           else
             echo "Skipping issue closing for development build"


### PR DESCRIPTION
## Summary
- Added automatic issue closing to all build workflows (Docker Engine, CLI, Compose, Tini)
- Workflows now search for tracking issues by label and version after successful release
- Issues are commented with release link and closed with "completed" reason
- Added `issues:write` permission to all build workflows
- **NEW:** Added periodic cleanup workflow to remove old development releases

## Problem 1: Tracking Issues Not Closing
Tracking issues created by `track-moby-releases.yml` and `track-cli-releases.yml` remained open after successful builds, requiring manual closure. The issue body said "Close it once the release is published" but this was just a manual instruction with no automation.

## Solution 1: Auto-close Issues
Each build workflow now includes a "Close tracking issue" step that:
1. Searches for the tracking issue using labels (`build-in-progress` + component-specific) and version in title
2. Comments on the issue with the release link
3. Closes the issue with reason "completed"
4. Only processes official version releases (skips development builds)

## Problem 2: Old Dev Releases Not Cleaned Up
Development releases accumulate over time (e.g., `compose-v20251102-dev` from November still exists). The current delete logic only removes the exact same release name, so weekly builds create new dated releases without cleaning up old ones.

## Solution 2: Periodic Cleanup Workflow
Created `cleanup-old-dev-releases.yml` that:
- Runs weekly on Saturdays at 01:00 UTC (before Sunday builds)
- Deletes dev releases older than 30 days (configurable)
- Supports all component types (Docker, CLI, Compose, Tini, BuildX, BuildKit, cagent)
- Includes dry-run mode for safe testing
- Can be triggered manually with custom retention period
- Provides detailed logging of deletions

## Test plan
- [ ] Trigger a test build: `gh workflow run docker-weekly-build.yml -f moby_ref=v27.5.1`
- [ ] Verify the tracking issue gets closed automatically after release is published
- [ ] Check that the issue has a comment with the release link
- [ ] Verify dev builds don't attempt to close issues
- [ ] Run cleanup in dry-run mode: `gh workflow run cleanup-old-dev-releases.yml -f dry_run=true`
- [ ] Verify cleanup identifies old dev releases correctly
- [ ] Run cleanup for real to remove old releases: `gh workflow run cleanup-old-dev-releases.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflows now automatically locate, comment on, and close matching tracking issues after official releases, reducing manual follow-up.
  * Workflow permissions updated to allow writing to issues (and release contents where required).
  * New scheduled cleanup job: weekly task to identify and optionally remove old development releases with configurable retention and dry-run support, plus detailed summary reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->