### PR TITLE
fix(ci): prevent cleanup workflow failure with set -e when processing releases

### DIFF
--- a/.github/workflows/cleanup-old-dev-releases.yml
+++ b/.github/workflows/cleanup-old-dev-releases.yml
@@ -132,7 +132,7 @@ jobs:
                 echo "✅ Keeping: $TAG (${AGE_DAYS} days old, within retention period)"
                 ((TOTAL_SKIPPED++))
               fi
-            done <<< "$MATCHING_RELEASES"
+            done <<< "$MATCHING_RELEASES" || true
           done
 
           echo ""


### PR DESCRIPTION
## Summary
- Fixed cleanup workflow failure caused by while read loop returning non-zero status

## Problem
The cleanup workflow (run #20849599543) failed with exit code 1 after processing releases. The issue was that the `while read` loop exits with non-zero status when it finishes reading input, which causes the script to fail immediately due to `set -euo pipefail`.

## Solution
Added `|| true` after the `done <<< "$MATCHING_RELEASES"` line to ensure the loop always returns success, preventing the script from failing when the read command naturally exits.

## Test plan
- [x] Verified fix locally
- [ ] Trigger cleanup workflow manually to verify it completes successfully
- [ ] Check that releases are processed correctly

## References
- Fixes workflow run: https://github.com/gounthar/docker-for-riscv64/actions/runs/20849599543

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced reliability of internal release cleanup process to better handle edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->