### PR TITLE
fix(ci): add automatic tracking issue closure to cagent workflow

### DIFF
--- a/.github/workflows/cagent-weekly-build.yml
+++ b/.github/workflows/cagent-weekly-build.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: write
   actions: write
+  issues: write
 
 jobs:
   build-cagent:
@@ -211,3 +212,49 @@ jobs:
           fi
 
           echo "✓ Package builds triggered successfully"
+
+      - name: Close tracking issue
+        if: ${{ success() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          CAGENT_REF="${{ github.event.inputs.cagent_ref || 'main' }}"
+
+          # Only close issues for official releases (not dev builds)
+          if [[ "$CAGENT_REF" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+            # Normalize version format to match release creation
+            CLEAN_REF="${CAGENT_REF#v}"
+            VERSION_TAG="v${CLEAN_REF}"
+            RELEASE_VERSION="cagent-${VERSION_TAG}-riscv64"
+
+            echo "Searching for tracking issue for cagent ${VERSION_TAG}..."
+
+            # Find the issue by label and title
+            ISSUE_NUMBER=$(gh issue list \
+              --label "build-in-progress,cagent-release" \
+              --state open \
+              --limit 200 \
+              --json number,title \
+              --jq ".[] | select(.title | contains(\"${VERSION_TAG}\")) | .number" \
+              | head -n1)
+
+            if [ -n "$ISSUE_NUMBER" ]; then
+              echo "Found tracking issue #${ISSUE_NUMBER}"
+
+              # Comment on the issue with release link
+              gh issue comment "$ISSUE_NUMBER" \
+                --body "Build completed successfully! Release published: https://github.com/${{ github.repository }}/releases/tag/${RELEASE_VERSION}"
+
+              # Close the issue
+              gh issue close "$ISSUE_NUMBER" \
+                --reason completed \
+                --comment "Automatically closing - release published."
+
+              echo "Issue #${ISSUE_NUMBER} closed successfully"
+            else
+              echo "No tracking issue found for ${VERSION_TAG}"
+            fi
+          else
+            echo "Skipping issue closing for development build"
+          fi


### PR DESCRIPTION
## Summary

Add missing "Close tracking issue" step to `cagent-weekly-build.yml` to automatically close tracking issues created by `track-cagent-releases.yml` after successful builds.

This completes the tracking issue auto-close feature across all build workflows.

## Changes

- Add `issues:write` permission to cagent workflow
- Add "Close tracking issue" step that:
  - Searches for tracking issues by label (`build-in-progress`, `cagent-release`)
  - Comments with release link
  - Closes issue with "completed" reason
  - Only runs for official releases (not dev builds)

## Issue Cleanup

Manually closed 6 existing open cagent tracking issues that were created before this automation was added:

- #267 - cagent v1.19.0
- #265 - cagent v1.18.8
- #262 - cagent v1.18.6
- #261 - cagent v1.18.1
- #259 - cagent v1.17.0
- #257 - cagent v1.16.0

All tracking issues now have the auto-close feature:
- ✅ Docker Engine (`docker-weekly-build.yml`)
- ✅ Docker CLI (`cli-weekly-build.yml`)
- ✅ Docker Compose (`compose-weekly-build.yml`)
- ✅ Tini (`tini-weekly-build.yml`)
- ✅ cagent (`cagent-weekly-build.yml`) - **this PR**

## Testing

All 6 cagent releases exist and have been linked in the closed issues:
- cagent-v1.19.0-riscv64
- cagent-v1.18.8-riscv64
- cagent-v1.18.6-riscv64
- cagent-v1.18.1-riscv64
- cagent-v1.17.0-riscv64
- cagent-v1.16.0-riscv64

No more open tracking issues with `build-in-progress` label remain.