### PR TITLE
fix(ci): add retry logic to APT repository package downloads

### DIFF
--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -170,34 +170,44 @@ jobs:
           # Download Engine packages (docker.io, containerd, runc)
           if [ -n "$DOCKER_RELEASE" ]; then
             echo "Downloading Engine packages from $DOCKER_RELEASE..."
-            download_package "$DOCKER_RELEASE" 'docker.io_*.deb' 'docker.io' || FAILED_DOWNLOADS+=("docker.io from $DOCKER_RELEASE")
-            download_package "$DOCKER_RELEASE" 'containerd_*.deb' 'containerd' || FAILED_DOWNLOADS+=("containerd from $DOCKER_RELEASE")
-            download_package "$DOCKER_RELEASE" 'runc_*.deb' 'runc' || FAILED_DOWNLOADS+=("runc from $DOCKER_RELEASE")
+            download_package "$DOCKER_RELEASE" 'docker.io_*.deb' 'docker.io' || \
+              FAILED_DOWNLOADS+=("docker.io from $DOCKER_RELEASE")
+            download_package "$DOCKER_RELEASE" 'containerd_*.deb' 'containerd' || \
+              FAILED_DOWNLOADS+=("containerd from $DOCKER_RELEASE")
+            download_package "$DOCKER_RELEASE" 'runc_*.deb' 'runc' || \
+              FAILED_DOWNLOADS+=("runc from $DOCKER_RELEASE")
           fi
 
           # Download CLI package
           if [ -n "$CLI_RELEASE" ]; then
-            download_package "$CLI_RELEASE" 'docker-cli_*.deb' 'docker-cli' || FAILED_DOWNLOADS+=("docker-cli from $CLI_RELEASE")
+            download_package "$CLI_RELEASE" 'docker-cli_*.deb' 'docker-cli' || \
+              FAILED_DOWNLOADS+=("docker-cli from $CLI_RELEASE")
           fi
 
           # Download Compose package
           if [ -n "$COMPOSE_RELEASE" ]; then
-            download_package "$COMPOSE_RELEASE" 'docker-compose-plugin_*.deb' 'docker-compose-plugin' || FAILED_DOWNLOADS+=("docker-compose-plugin from $COMPOSE_RELEASE")
+            download_package "$COMPOSE_RELEASE" 'docker-compose-plugin_*.deb' \
+              'docker-compose-plugin' || \
+              FAILED_DOWNLOADS+=("docker-compose-plugin from $COMPOSE_RELEASE")
           fi
 
           # Download Buildx package
           if [ -n "$BUILDX_RELEASE" ]; then
-            download_package "$BUILDX_RELEASE" 'docker-buildx-plugin_*.deb' 'docker-buildx-plugin' || FAILED_DOWNLOADS+=("docker-buildx-plugin from $BUILDX_RELEASE")
+            download_package "$BUILDX_RELEASE" 'docker-buildx-plugin_*.deb' \
+              'docker-buildx-plugin' || \
+              FAILED_DOWNLOADS+=("docker-buildx-plugin from $BUILDX_RELEASE")
           fi
 
           # Download cagent package
           if [ -n "$CAGENT_RELEASE" ]; then
-            download_package "$CAGENT_RELEASE" 'cagent_*.deb' 'cagent' || FAILED_DOWNLOADS+=("cagent from $CAGENT_RELEASE")
+            download_package "$CAGENT_RELEASE" 'cagent_*.deb' 'cagent' || \
+              FAILED_DOWNLOADS+=("cagent from $CAGENT_RELEASE")
           fi
 
           # Download BuildKit package
           if [ -n "$BUILDKIT_RELEASE" ]; then
-            download_package "$BUILDKIT_RELEASE" 'buildkit_*.deb' 'buildkit' || FAILED_DOWNLOADS+=("buildkit from $BUILDKIT_RELEASE")
+            download_package "$BUILDKIT_RELEASE" 'buildkit_*.deb' 'buildkit' || \
+              FAILED_DOWNLOADS+=("buildkit from $BUILDKIT_RELEASE")
           fi
 
           # Report download failures
@@ -210,6 +220,9 @@ jobs:
             echo "  1. Package not yet available in release (CDN propagation delay)"
             echo "  2. Package build failed or was skipped"
             echo "  3. Network or authentication issue"
+            echo ""
+            echo "Verify releases manually at:"
+            echo "  https://github.com/gounthar/docker-for-riscv64/releases"
             echo ""
             echo "Continuing with available packages..."
           fi


### PR DESCRIPTION
## Summary

Fixes race condition that caused APT repository to miss package updates when workflows triggered immediately after package upload.

## Problem

The cli-v29.1.4-riscv64 release was created with a Debian package, but the APT repository still contained version 29.1.3. Investigation revealed:

1. **Timeline**:
   - CLI package uploaded: `2026-01-11 04:58:50 UTC`
   - APT update workflow triggered: `2026-01-11 04:59:00 UTC` (10 seconds later)

2. **Root Cause**:
   - Package downloads used `|| true`, masking failures
   - GitHub releases CDN can have brief propagation delays
   - When download failed, workflow continued silently
   - Workflow saw "no changes" and exited without committing

3. **Impact**:
   - Silent failures left APT repository out of sync with releases
   - Users couldn't install latest versions via APT

## Solution

- Add `download_package()` function with retry logic (3 attempts, 5s delay)
- Remove `|| true` to properly detect download failures
- Track and report failed downloads with diagnostic info
- Add clear success/failure logging for each package

## Changes

- Modified `.github/workflows/update-apt-repo.yml`
- Package downloads now retry up to 3 times with 5-second delay
- Failed downloads are tracked and reported
- Workflow continues with available packages but logs failures

## Testing

- [x] Manual trigger confirmed cli-v29.1.4 successfully added to APT repo
- [ ] Next automatic workflow run will test retry logic

## Related Issues

Closes #XXX (if issue exists)

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved package download resilience with automatic retry and centralized handling of failed downloads.
  * Added concise failure reporting that lists packages that couldn't be retrieved while allowing the process to continue with available assets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->