### PR TITLE
fix(ci): add direct package build triggers to weekly build workflows

### DIFF
--- a/.github/workflows/buildkit-weekly-build.yml
+++ b/.github/workflows/buildkit-weekly-build.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: write
   packages: write
+  actions: write
 
 jobs:
   build-buildkit:
@@ -368,3 +369,32 @@ jobs:
             release-buildkit-$DATE/*
 
           echo "Release created: $RELEASE_VERSION"
+
+      - name: Trigger package builds
+        if: ${{ success() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          BUILDKIT_REF="${{ github.event.inputs.buildkit_ref || 'master' }}"
+
+          # Only trigger package builds for official releases (not dev builds)
+          if [[ "$BUILDKIT_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
+            RELEASE_TAG="buildkit-${BUILDKIT_REF}-riscv64"
+
+            echo "Triggering package builds for $RELEASE_TAG..."
+
+            # Trigger Debian package build
+            gh workflow run build-buildkit-package.yml -f release_tag="$RELEASE_TAG"
+            echo "✓ Triggered build-buildkit-package.yml"
+
+            # Trigger RPM package build
+            gh workflow run build-buildkit-rpm.yml -f release_tag="$RELEASE_TAG"
+            echo "✓ Triggered build-buildkit-rpm.yml"
+
+            echo ""
+            echo "Package builds triggered successfully!"
+            echo "Monitor progress: gh run list --workflow=build-buildkit-package.yml --limit 1"
+          else
+            echo "Skipping package builds for development build"
+          fi

--- a/.github/workflows/buildx-weekly-build.yml
+++ b/.github/workflows/buildx-weekly-build.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   build-buildx:

--- a/.github/workflows/cli-weekly-build.yml
+++ b/.github/workflows/cli-weekly-build.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: write
   issues: write
+  actions: write
 
 jobs:
   build-cli:
@@ -191,4 +192,34 @@ jobs:
             fi
           else
             echo "Skipping issue closing for development build"
+          fi
+
+      - name: Trigger package builds
+        if: ${{ success() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          CLI_REF="${{ github.event.inputs.cli_ref || 'master' }}"
+
+          # Only trigger package builds for official releases (not dev builds)
+          if [[ "$CLI_REF" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+            CLEAN_REF="${CLI_REF#v}"
+            RELEASE_TAG="cli-v${CLEAN_REF}-riscv64"
+
+            echo "Triggering package builds for $RELEASE_TAG..."
+
+            # Trigger Debian package build
+            gh workflow run build-cli-package.yml -f release_tag="$RELEASE_TAG"
+            echo "✓ Triggered build-cli-package.yml"
+
+            # Trigger RPM package build
+            gh workflow run build-cli-rpm.yml -f release_tag="$RELEASE_TAG"
+            echo "✓ Triggered build-cli-rpm.yml"
+
+            echo ""
+            echo "Package builds triggered successfully!"
+            echo "Monitor progress: gh run list --workflow=build-cli-package.yml --limit 1"
+          else
+            echo "Skipping package builds for development build"
           fi

--- a/.github/workflows/compose-weekly-build.yml
+++ b/.github/workflows/compose-weekly-build.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: write
   issues: write
+  actions: write
 
 jobs:
   build-compose:
@@ -197,4 +198,34 @@ jobs:
             fi
           else
             echo "Skipping issue closing for development build"
+          fi
+
+      - name: Trigger package builds
+        if: ${{ success() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          COMPOSE_REF="${{ github.event.inputs.compose_ref || 'main' }}"
+
+          # Only trigger package builds for official releases (not dev builds)
+          if [[ "$COMPOSE_REF" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+            CLEAN_REF="${COMPOSE_REF#v}"
+            RELEASE_TAG="compose-v${CLEAN_REF}-riscv64"
+
+            echo "Triggering package builds for $RELEASE_TAG..."
+
+            # Trigger Debian package build
+            gh workflow run build-compose-package.yml -f release_tag="$RELEASE_TAG"
+            echo "✓ Triggered build-compose-package.yml"
+
+            # Trigger RPM package build
+            gh workflow run build-compose-rpm.yml -f release_tag="$RELEASE_TAG"
+            echo "✓ Triggered build-compose-rpm.yml"
+
+            echo ""
+            echo "Package builds triggered successfully!"
+            echo "Monitor progress: gh run list --workflow=build-compose-package.yml --limit 1"
+          else
+            echo "Skipping package builds for development build"
           fi

--- a/.github/workflows/docker-weekly-build.yml
+++ b/.github/workflows/docker-weekly-build.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: write
   issues: write
+  actions: write
 
 jobs:
   build-docker:
@@ -322,4 +323,35 @@ jobs:
             fi
           else
             echo "Skipping issue closing for development build"
+          fi
+
+      - name: Trigger package builds
+        if: ${{ success() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          MOBY_REF="${{ github.event.inputs.moby_ref || 'master' }}"
+          VERSION_REGEX='${{ env.VERSION_REGEX }}'
+
+          # Only trigger package builds for official releases (not dev builds)
+          if [[ "$MOBY_REF" =~ $VERSION_REGEX ]]; then
+            VERSION_TAG="${MOBY_REF#docker-}"
+            RELEASE_TAG="${VERSION_TAG}-riscv64"
+
+            echo "Triggering package builds for $RELEASE_TAG..."
+
+            # Trigger Debian package build
+            gh workflow run build-debian-package.yml -f release_tag="$RELEASE_TAG"
+            echo "✓ Triggered build-debian-package.yml"
+
+            # Trigger RPM package build
+            gh workflow run build-rpm-package.yml -f release_tag="$RELEASE_TAG"
+            echo "✓ Triggered build-rpm-package.yml"
+
+            echo ""
+            echo "Package builds triggered successfully!"
+            echo "Monitor progress: gh run list --workflow=build-debian-package.yml --limit 1"
+          else
+            echo "Skipping package builds for development build"
           fi

--- a/.github/workflows/tini-weekly-build.yml
+++ b/.github/workflows/tini-weekly-build.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: write
   issues: write
+  actions: write
 
 jobs:
   build-tini:
@@ -247,4 +248,31 @@ jobs:
             fi
           else
             echo "Skipping issue closing for development build"
+          fi
+
+      - name: Trigger package builds
+        if: ${{ success() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TINI_REF="${{ github.event.inputs.tini_ref || 'v0.19.0' }}"
+
+          # Only trigger package builds for official releases (not dev builds)
+          if [[ "$TINI_REF" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+            # Normalize to ensure leading v for tag
+            TINI_TAG="v${TINI_REF#v}"
+            RELEASE_TAG="tini-${TINI_TAG}-riscv64"
+
+            echo "Triggering package builds for $RELEASE_TAG..."
+
+            # Trigger RPM package build (tini is primarily for RPM-based distros)
+            gh workflow run build-tini-rpm.yml -f release_tag="$RELEASE_TAG"
+            echo "✓ Triggered build-tini-rpm.yml"
+
+            echo ""
+            echo "Package builds triggered successfully!"
+            echo "Monitor progress: gh run list --workflow=build-tini-rpm.yml --limit 1"
+          else
+            echo "Skipping package builds for development build"
           fi


### PR DESCRIPTION
## Summary

- Fixed automation gap where package builds were not triggered when Track workflows detected new upstream releases
- Root cause: GitHub Actions token limitation prevents workflow_run events from firing when the triggering workflow was initiated via GITHUB_TOKEN
- Solution: Add explicit package build triggers at the end of weekly build workflows

## Problem

When `track-*-releases` workflows detect new upstream releases, they trigger weekly builds via `gh workflow run` using `GITHUB_TOKEN`. According to [GitHub Actions documentation](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow):

> "When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, **will not create a new workflow run**."

This means while the weekly build itself runs (workflow_dispatch is an exception), the subsequent `workflow_run` events that should trigger package builds **don't fire**.

Timeline example for CLI v29.1.5:
1. `track-cli-releases` detects v29.1.5 upstream, triggers `cli-weekly-build` via GITHUB_TOKEN
2. `cli-weekly-build` runs successfully, creates `cli-v29.1.5-riscv64` release
3. `build-cli-package` **not triggered** (workflow_run event not fired)
4. Result: Binary release exists but no .deb or .rpm packages

## Solution

Add explicit `gh workflow run` calls at the end of each weekly build workflow to directly trigger package builds after creating releases. This bypasses the workflow_run limitation.

## Changes

| Workflow | Package Triggers Added |
|----------|----------------------|
| `cli-weekly-build.yml` | `build-cli-package.yml`, `build-cli-rpm.yml` |
| `compose-weekly-build.yml` | `build-compose-package.yml`, `build-compose-rpm.yml` |
| `docker-weekly-build.yml` | `build-debian-package.yml`, `build-rpm-package.yml` |
| `buildkit-weekly-build.yml` | `build-buildkit-package.yml`, `build-buildkit-rpm.yml` |
| `buildx-weekly-build.yml` | (already had triggers, added `actions:write` permission) |
| `tini-weekly-build.yml` | `build-tini-rpm.yml` |

All workflows now have `actions: write` permission to allow workflow triggering.

## Test plan

- [ ] Verify workflows pass linting
- [ ] Test by manually triggering `cli-weekly-build` with `cli_ref=v29.1.5` to confirm package builds are triggered
- [ ] Confirm package builds complete and upload packages to existing release

## Related

Fixes the automation issue affecting:
- https://github.com/gounthar/docker-for-riscv64/releases/tag/cli-v29.1.5-riscv64 (missing packages)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release workflows now automatically trigger package builds for official releases across all projects, eliminating manual build steps and significantly streamlining the deployment process while ensuring consistent and reliable package generation for each release.
  * Workflow permissions have been enhanced to support improved build orchestration and automation capabilities during official release processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->