### PR TITLE
fix(ci): add concurrency group to prevent APT/RPM repo update conflicts

### DIFF
--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -21,7 +21,7 @@ on:
         default: 'v28.5.2-riscv64'
 
 concurrency:
-  group: apt-repo-branch-updates
+  group: repo-branch-updates
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/update-rpm-repo.yml
+++ b/.github/workflows/update-rpm-repo.yml
@@ -16,7 +16,7 @@ env:
   GPG_KEY_ID: '56188341425B007407229B48FB1963FC3575A39D'
 
 concurrency:
-  group: apt-repo-branch-updates
+  group: repo-branch-updates
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- Add concurrency group `apt-repo-branch-updates` to `update-apt-repo.yml`
- Add same concurrency group to `update-rpm-repo.yml`
- Use `cancel-in-progress: false` to queue updates instead of canceling them

## Problem
Both workflows push to the same `apt-repo` branch. When multiple package builds complete simultaneously (e.g., Docker Engine + CLI + Compose), the repository update workflows run concurrently and cause push conflicts:

```
error: failed to push some refs to 'https://github.com/gounthar/docker-for-riscv64'
```

This resulted in docker.io 29.1.5 being available in the GitHub release but missing from the APT repository, causing users to not receive updates.

## Solution
GitHub Actions concurrency groups serialize workflow runs. By using the same group name in both APT and RPM update workflows with `cancel-in-progress: false`, updates are queued and executed one at a time.

## Test plan
- [ ] Trigger multiple package builds that complete around the same time
- [ ] Verify repository update workflows queue rather than conflict
- [ ] Confirm all packages are successfully added to the repository

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added concurrency configuration to APT and RPM repository update workflows, introducing a shared concurrency group and setting in-progress cancellations to false.
  * No functional changes to workflow steps or repository update logic; one minor non-functional formatting tweak.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->