### PR TITLE
feat(ci): add cleanup workflow for old repo packages

### DIFF
--- a/.github/workflows/cleanup-repo-packages.yml
+++ b/.github/workflows/cleanup-repo-packages.yml
@@ -70,6 +70,9 @@ jobs:
           echo "Dry run: $DRY_RUN"
           echo ""
 
+          # Packages to never remove (rarely rebuilt, would disappear from repo)
+          PROTECTED_PACKAGES="tini containerd runc docker-compose-plugin"
+
           APT_REMOVED=0
           APT_KEPT=0
 
@@ -94,6 +97,13 @@ jobs:
             [ -d "$pkg_dir" ] || continue
 
             pkg_name=$(basename "$pkg_dir")
+
+            # Skip protected packages
+            if echo "$PROTECTED_PACKAGES" | grep -qw "$pkg_name"; then
+              echo "Package: $pkg_name (PROTECTED, skipping)"
+              continue
+            fi
+
             debs=()
             while IFS= read -r f; do
               [ -f "$f" ] && debs+=("$f")
@@ -175,6 +185,9 @@ jobs:
             fi
           done < <(git log --diff-filter=A --name-only --format="DATE:%ct" -- "$RPM_DIR/" 2>/dev/null)
 
+          # Packages to never remove (rarely rebuilt, would disappear from repo)
+          PROTECTED_PACKAGES="tini tini-static containerd runc docker-compose-plugin"
+
           # Group RPM files by package name using NVR parsing
           declare -A RPM_PACKAGES
           for rpm_file in "$RPM_DIR"/*.rpm; do
@@ -197,6 +210,12 @@ jobs:
           RPM_KEPT=0
 
           for pkg_name in $(echo "${!RPM_PACKAGES[@]}" | tr ' ' '\n' | sort -u); do
+            # Skip protected packages
+            if echo "$PROTECTED_PACKAGES" | grep -qw "$pkg_name"; then
+              echo "Package: $pkg_name (PROTECTED, skipping)"
+              continue
+            fi
+
             # Sort files by version (newest first)
             files=()
             while IFS= read -r f; do


### PR DESCRIPTION
## Summary

- Add `cleanup-repo-packages.yml` workflow to prune old APT and RPM package versions from the `apt-repo` branch
- The branch has grown to 2.9 GB (1.27 GB .deb + 1.65 GB .rpm), exceeding GitHub Pages' 1 GB limit
- Retention policy: keep latest 3 versions per package OR anything newer than 90 days (whichever is more generous)
- Runs weekly (Sunday 09:00 UTC, after builds complete) and supports manual dispatch with dry-run mode

## Problem

GitHub Pages builds started failing because the `apt-repo` branch accumulated every package version ever built (e.g., 29 cagent versions, 13 docker-cli versions). This blocks end users from installing packages via `apt`/`dnf`.

## How it works

1. Checks out `apt-repo` branch with full git history
2. Groups `.deb` files in `pool/` by package name, sorts by version
3. Groups `.rpm` files in `rpm/fedora/riscv64/` by package name, sorts by version
4. For each package: keeps the latest N versions + any version committed less than 90 days ago
5. Removes the rest with `git rm`
6. Rebuilds RPM metadata with `createrepo_c`
7. Commits and pushes to `apt-repo`

## Test plan

- [ ] Merge PR
- [ ] Run workflow with `dry_run: true` to verify retention logic
- [ ] Run workflow without dry-run to perform actual cleanup
- [ ] Verify GitHub Pages deploys successfully after cleanup
- [ ] Verify `apt-get update` works against the cleaned repo
- [ ] Verify `dnf repolist` works against the cleaned repo

## Configuration

| Parameter | Default | Description |
|-----------|---------|-------------|
| `dry_run` | `false` | Preview mode |
| `keep_versions` | `3` | Min versions per package |
| `keep_days` | `90` | Age threshold in days |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated weekly cleanup for repository packages with configurable retention (versions/days) for both APT and RPM formats.
  * Supports manual triggering and dry-run mode to preview actions without committing.
  * Rebuilds package metadata only when removals occur and commits/pushes changes when not a dry run.
  * Appends a summarized report of removed packages to the workflow results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->