### PR TITLE
fix(ci): use safe arithmetic in cleanup workflow

### DIFF
--- a/.github/workflows/cleanup-repo-packages.yml
+++ b/.github/workflows/cleanup-repo-packages.yml
@@ -121,13 +121,13 @@ jobs:
 
               if [ "$kept" -lt "$KEEP_VERSIONS" ] || [ "$commit_date" -ge "$CUTOFF_EPOCH" ]; then
                 echo "  KEEP: $fname"
-                ((kept++))
+                kept=$((kept + 1))
               else
                 echo "  REMOVE: $fname"
                 if [ "$DRY_RUN" != "true" ]; then
                   git rm -q "$deb"
                 fi
-                ((APT_REMOVED++))
+                APT_REMOVED=$((APT_REMOVED + 1))
               fi
             done
             APT_KEPT=$((APT_KEPT + kept))
@@ -234,13 +234,13 @@ jobs:
 
               if [ "$kept" -lt "$KEEP_VERSIONS" ] || [ "$commit_date" -ge "$CUTOFF_EPOCH" ]; then
                 echo "  KEEP: $fname"
-                ((kept++))
+                kept=$((kept + 1))
               else
                 echo "  REMOVE: $fname"
                 if [ "$DRY_RUN" != "true" ]; then
                   git rm -q "$rpm_file"
                 fi
-                ((RPM_REMOVED++))
+                RPM_REMOVED=$((RPM_REMOVED + 1))
               fi
             done
             RPM_KEPT=$((RPM_KEPT + kept))


### PR DESCRIPTION
## Summary

- Replace `((var++))` with `var=$((var + 1))` in cleanup workflow
- Prevents `set -e` failure when variable is 0 (bash `((0++))` returns exit code 1)

## Context

The dry run of the cleanup workflow (#293) failed because `((kept++))` was called when `kept=0`. In bash, `((expr))` returns the expression value as exit status, and post-increment returns the **old** value — so `((0++))` returns exit code 1, which `set -e` treats as failure.

## Test plan

- [ ] Re-run cleanup workflow with `dry_run=true` after merge
- [ ] Verify no arithmetic exit code failures