### PR TITLE
fix(ci): lower default keep_days from 90 to 30

### DIFF
--- a/.github/workflows/cleanup-repo-packages.yml
+++ b/.github/workflows/cleanup-repo-packages.yml
@@ -16,7 +16,7 @@ on:
       keep_days:
         description: 'Keep packages newer than this many days'
         type: number
-        default: 90
+        default: 30
 
 permissions:
   contents: write
@@ -50,7 +50,7 @@ jobs:
             echo "dry_run=${{ github.event.inputs.dry_run }}" >> "$GITHUB_OUTPUT"
           else
             echo "keep_versions=3" >> "$GITHUB_OUTPUT"
-            echo "keep_days=90" >> "$GITHUB_OUTPUT"
+            echo "keep_days=30" >> "$GITHUB_OUTPUT"
             echo "dry_run=false" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## Summary

- Lower default `keep_days` from 90 to 30 in cleanup workflow
- 90 days keeps nearly all packages since builds happen weekly, making cleanup ineffective
- 30 days retains ~4 weeks of builds beyond the top 3 versions

## Context

Dry run comparison showed:
- `keep_days=90`: only 4 packages removed (repo stays at ~2.9 GB)
- `keep_days=30`: 87 packages removed (sufficient to get under GitHub Pages' 1 GB limit)

## Test plan

- [x] Dry run with `keep_days=30` succeeded (run 21394523998)
- [ ] Run actual cleanup after merge