### PR TITLE
fix(ci): rebuild reprepro DB from pool files during cleanup

### DIFF
--- a/.github/workflows/cleanup-repo-packages.yml
+++ b/.github/workflows/cleanup-repo-packages.yml
@@ -145,11 +145,28 @@ jobs:
           echo "Importing GPG key for signing..."
           echo "$GPG_PRIVATE_KEY" | gpg --batch --import
 
-          echo "Removing unreferenced pool files from reprepro DB..."
-          reprepro -b . deleteunreferenced
+          # The reprepro DB (db/) is in .gitignore and not tracked in git.
+          # We must rebuild it from scratch using all remaining .deb files.
+          echo "Rebuilding reprepro DB from remaining pool files..."
 
-          echo "Re-exporting APT repository metadata..."
-          reprepro -b . export
+          # Re-add all remaining pool .deb files
+          for deb in pool/main/*/*/*.deb; do
+            [ -f "$deb" ] || continue
+            echo "  Adding: $(basename "$deb")"
+            reprepro -b . includedeb trixie "$deb" 2>/dev/null || true
+          done
+
+          # Also include root-level .deb files (legacy packages)
+          for deb in *.deb; do
+            [ -f "$deb" ] || continue
+            echo "  Adding root: $deb"
+            reprepro -b . includedeb trixie "$deb" 2>/dev/null || true
+          done
+
+          echo ""
+          echo "Repository contents after rebuild:"
+          reprepro -b . list trixie
+          echo ""
 
           echo "APT metadata rebuilt"
           git add dists/ pool/


### PR DESCRIPTION
## Summary

- Fix APT metadata rebuild in cleanup workflow
- The reprepro DB (`db/`) is in `.gitignore` and not tracked in git
- Previous approach ran `reprepro deleteunreferenced` + `export` on an empty DB, producing empty `Packages` metadata
- New approach rebuilds the DB from scratch by re-adding all remaining `.deb` files

## Root Cause

The cleanup workflow wiped APT metadata because:
1. `db/` is gitignored on the `apt-repo` branch
2. Checkout gives a fresh environment with no reprepro database
3. `reprepro export` with empty DB = empty Packages file
4. GitHub Pages served empty metadata = `apt update` finds no packages

## Fix

Replace `deleteunreferenced`/`export` with full DB rebuild:
- Scan `pool/main/*/*/*.deb` for all remaining pool packages
- Scan `*.deb` for root-level legacy packages
- `reprepro includedeb trixie` each one to populate the DB
- reprepro automatically generates correct metadata

## Test plan

- [x] APT repo update triggered to fix immediate metadata issue
- [ ] Next cleanup run will use the corrected rebuild approach