### PR TITLE
fix(ci): add issues:write permission for build issue closing

### DIFF
--- a/.github/workflows/buildkit-weekly-build.yml
+++ b/.github/workflows/buildkit-weekly-build.yml
@@ -15,6 +15,7 @@ permissions:
   contents: write
   packages: write
   actions: write
+  issues: write
 
 jobs:
   build-buildkit:

--- a/.github/workflows/buildx-weekly-build.yml
+++ b/.github/workflows/buildx-weekly-build.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: write
   actions: write
+  issues: write
 
 jobs:
   build-buildx:


### PR DESCRIPTION
## Summary

- Add `issues: write` permission to `buildkit-weekly-build.yml` and `buildx-weekly-build.yml`

## Problem

PR #298 added a "Close build-in-progress issue" step to both workflows, but didn't add the required `issues: write` permission. Without it, `gh issue list` and `gh issue close` would fail at runtime with a permission error.

Caught by CodeRabbit review on #298.

## Test plan

- [ ] Verify next BuildKit/Buildx build closes its tracking issue without permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to support issue management in automated build processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->