### PR TITLE
fix(ci): trigger APT repo update from package build workflows

### DIFF
--- a/.github/workflows/build-buildkit-package.yml
+++ b/.github/workflows/build-buildkit-package.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   build-deb:
@@ -265,3 +266,9 @@ jobs:
           echo "  sudo dpkg -i buildkit_*.deb"
           echo "  buildkitd --version"
           echo "  buildctl --version"
+
+          # Trigger APT repository update
+          # Cannot rely on workflow_run events due to GITHUB_TOKEN limitation
+          echo ""
+          echo "Triggering APT repository update..."
+          gh workflow run update-apt-repo.yml -f release_tag="$RELEASE_TAG" || echo "Warning: Failed to trigger APT repo update"

--- a/.github/workflows/build-buildx-package.yml
+++ b/.github/workflows/build-buildx-package.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   build-deb:
@@ -200,3 +201,9 @@ jobs:
           echo "  wget https://github.com/gounthar/docker-for-riscv64/releases/download/${RELEASE_TAG}/docker-buildx-plugin_*.deb"
           echo "  sudo dpkg -i docker-buildx-plugin_*.deb"
           echo "  docker buildx version"
+
+          # Trigger APT repository update
+          # Cannot rely on workflow_run events due to GITHUB_TOKEN limitation
+          echo ""
+          echo "Triggering APT repository update..."
+          gh workflow run update-apt-repo.yml -f release_tag="$RELEASE_TAG" || echo "Warning: Failed to trigger APT repo update"

--- a/.github/workflows/build-cagent-package.yml
+++ b/.github/workflows/build-cagent-package.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   build-deb:
@@ -232,3 +233,9 @@ jobs:
           echo "  wget https://github.com/gounthar/docker-for-riscv64/releases/download/${RELEASE_TAG}/cagent_*.deb"
           echo "  sudo dpkg -i cagent_*.deb"
           echo "  cagent version"
+
+          # Trigger APT repository update
+          # Cannot rely on workflow_run events due to GITHUB_TOKEN limitation
+          echo ""
+          echo "Triggering APT repository update..."
+          gh workflow run update-apt-repo.yml -f release_tag="$RELEASE_TAG" || echo "Warning: Failed to trigger APT repo update"

--- a/.github/workflows/build-cli-package.yml
+++ b/.github/workflows/build-cli-package.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   build-deb:
@@ -251,3 +252,9 @@ jobs:
           echo "  wget https://github.com/gounthar/docker-for-riscv64/releases/download/${RELEASE_TAG}/docker-cli_*.deb"
           echo "  sudo dpkg -i docker-cli_*.deb"
           echo "  docker --version"
+
+          # Trigger APT repository update
+          # Cannot rely on workflow_run events due to GITHUB_TOKEN limitation
+          echo ""
+          echo "Triggering APT repository update..."
+          gh workflow run update-apt-repo.yml -f release_tag="$RELEASE_TAG" || echo "Warning: Failed to trigger APT repo update"

--- a/.github/workflows/build-compose-package.yml
+++ b/.github/workflows/build-compose-package.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   build-deb:
@@ -191,3 +192,9 @@ jobs:
           echo "  wget https://github.com/gounthar/docker-for-riscv64/releases/download/${RELEASE_TAG}/docker-compose-plugin_*.deb"
           echo "  sudo dpkg -i docker-compose-plugin_*.deb"
           echo "  docker compose version"
+
+          # Trigger APT repository update
+          # Cannot rely on workflow_run events due to GITHUB_TOKEN limitation
+          echo ""
+          echo "Triggering APT repository update..."
+          gh workflow run update-apt-repo.yml -f release_tag="$RELEASE_TAG" || echo "Warning: Failed to trigger APT repo update"

--- a/.github/workflows/build-debian-package.yml
+++ b/.github/workflows/build-debian-package.yml
@@ -13,6 +13,10 @@ on:
         required: true
         default: 'v28.5.1-riscv64'
 
+permissions:
+  contents: write
+  actions: write
+
 jobs:
   build-deb:
     runs-on: [self-hosted, riscv64]
@@ -186,3 +190,9 @@ jobs:
           echo "  sudo dpkg -i containerd_*_riscv64.deb"
           echo "  sudo dpkg -i docker.io_*_riscv64.deb"
           echo "  sudo apt-get install -f"
+
+          # Trigger APT repository update
+          # Cannot rely on workflow_run events due to GITHUB_TOKEN limitation
+          echo ""
+          echo "Triggering APT repository update..."
+          gh workflow run update-apt-repo.yml -f release_tag="$RELEASE_TAG" || echo "Warning: Failed to trigger APT repo update"


### PR DESCRIPTION
## Summary

- Add explicit `gh workflow run update-apt-repo.yml` to all 6 Debian package workflows
- Add `actions: write` permission needed for `gh workflow run`

## Problem

When the release tracker detects a new upstream version, the chain is:

```
tracker → weekly build → package build → APT repo update
```

The `tracker → weekly build` step uses `GITHUB_TOKEN`, which means the weekly build's completion **doesn't fire `workflow_run` events** downstream (GitHub security limitation). The explicit `gh workflow run` in the weekly build triggers the package build, but the package build's completion also doesn't propagate `workflow_run` to `update-apt-repo.yml`.

**Result:** New packages get built and uploaded to releases, but the APT repository is never updated. Users running `apt update` don't see the new version.

This worked for scheduled Sunday builds (cron triggers don't use `GITHUB_TOKEN`) but failed for all tracker-triggered builds (daily release detection).

## Fix

Each package workflow now explicitly triggers `update-apt-repo.yml` after uploading `.deb` files, bypassing the broken `workflow_run` chain entirely.

The existing `workflow_run` trigger in `update-apt-repo.yml` is kept as a backup for scheduled builds.

## Affected workflows

| Workflow | Component |
|----------|-----------|
| `build-debian-package.yml` | Docker Engine |
| `build-compose-package.yml` | Docker Compose |
| `build-cli-package.yml` | Docker CLI |
| `build-buildx-package.yml` | Docker Buildx |
| `build-buildkit-package.yml` | BuildKit |
| `build-cagent-package.yml` | cagent |

## Test plan

- [x] Manually triggered APT update for buildx-v0.31.1-riscv64
- [ ] Verify next tracker-triggered build automatically updates the APT repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build workflow permissions to support automated APT repository updates after package releases across all platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->