### PR TITLE
fix(ci): bump Go version to 1.25.5 for Moby master

### DIFF
--- a/.github/workflows/docker-weekly-build.yml
+++ b/.github/workflows/docker-weekly-build.yml
@@ -139,7 +139,7 @@ jobs:
           echo "Building Docker with VERSION=$VERSION"
           docker build \
             --build-arg BASE_DEBIAN_DISTRO=trixie \
-            --build-arg GO_VERSION=1.25.3 \
+            --build-arg GO_VERSION=1.25.5 \
             --build-arg VERSION="$VERSION" \
             --target=binary \
             -f Dockerfile \
@@ -257,7 +257,7 @@ jobs:
           **Build Command:**
           \`\`\`bash
           docker build --build-arg BASE_DEBIAN_DISTRO=trixie \\
-                       --build-arg GO_VERSION=1.25.3 \\
+                       --build-arg GO_VERSION=1.25.5 \\
                        --target=binary \\
                        -f moby/Dockerfile .
           \`\`\`


### PR DESCRIPTION
## Summary

Moby master's `go.mod` now requires `go >= 1.25.5`. The Docker Engine build
was failing with `GO_VERSION=1.25.3`:

```
go: go.mod requires go >= 1.25.5 (running go 1.25.3; GOTOOLCHAIN=local)
```

Bumps `--build-arg GO_VERSION` from 1.25.3 to 1.25.5 in both the build step
and the release notes.

## Test plan

- [ ] Re-trigger `docker-weekly-build.yml` after merge to verify build succeeds