### PR TITLE
feat(ci): update containerd default from v1.7.28 to v2.2.1

### DIFF
--- a/.github/workflows/docker-weekly-build.yml
+++ b/.github/workflows/docker-weekly-build.yml
@@ -159,11 +159,15 @@ jobs:
       - name: Build containerd
         run: |
           CONTAINERD_REF="${{ github.event.inputs.containerd_ref || 'v2.2.1' }}"
-          # Clone containerd if not exists
+          # Clone if needed, then always sync to the requested ref
           if [ ! -d "containerd" ]; then
-            git clone --depth 1 --branch "$CONTAINERD_REF" https://github.com/containerd/containerd.git
+            git clone https://github.com/containerd/containerd.git
           fi
           cd containerd
+          git fetch --tags --prune origin
+          git checkout --force "$CONTAINERD_REF"
+          git reset --hard "$CONTAINERD_REF"
+          git clean -fdx
 
           # Build containerd binaries
           make BUILDTAGS='no_btrfs' binaries
@@ -178,11 +182,15 @@ jobs:
       - name: Build runc
         run: |
           RUNC_REF="${{ github.event.inputs.runc_ref || 'v1.4.0' }}"
-          # Clone runc if not exists
+          # Clone if needed, then always sync to the requested ref
           if [ ! -d "runc" ]; then
-            git clone --depth 1 --branch "$RUNC_REF" https://github.com/opencontainers/runc.git
+            git clone https://github.com/opencontainers/runc.git
           fi
           cd runc
+          git fetch --tags --prune origin
+          git checkout --force "$RUNC_REF"
+          git reset --hard "$RUNC_REF"
+          git clean -fdx
 
           # Build runc
           make static


### PR DESCRIPTION
## Summary

Docker Engine 29.x ships containerd v2.x:
- 29.0.0 → containerd v2.1.5
- 29.1.0 → containerd v2.2.0
- 29.2.0 → containerd v2.2.1

Moby's `go.mod` also depends on `containerd/containerd/v2 v2.2.1`.

Updates the default `containerd_ref` from v1.7.28 to v2.2.1 to match
upstream. The containerd release tracker (`track-containerd-releases.yml`)
was already correctly detecting v2.2.1 -- now the default aligns.

## Test plan

- [ ] After merge, trigger Docker Engine build to verify containerd v2.2.1 compiles
- [ ] Verify containerd binary version in release artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker weekly build workflow to use containerd v2.2.1 (was v1.7.28).
  * Improved synchronization of containerd and runc sources during builds to ensure correct refs are fetched.
  * Aligned all build stages to the new containerd ref and applied minor workflow formatting adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->