### PR TITLE
fix(ci): add issue deduplication to all release trackers

### DIFF
--- a/.github/workflows/track-buildkit-releases.yml
+++ b/.github/workflows/track-buildkit-releases.yml
@@ -64,7 +64,10 @@ jobs:
             --state all \
             --search "in:title Building BuildKit ${LATEST} for RISC-V64" \
             --json number,title \
-            --jq 'map(select(.title == "Building BuildKit '"${LATEST}"' for RISC-V64")) | .[0].number // empty')
+            --jq 'map(select(.title == "Building BuildKit '"${LATEST}"' for RISC-V64")) | .[0].number // empty') || {
+            echo "ERROR: gh issue list failed while checking duplicates for BuildKit ${LATEST}"
+            exit 1
+          }
 
           if [ -n "$EXISTING" ]; then
             echo "ℹ️ Tracking issue #$EXISTING already exists for BuildKit ${LATEST}, skipping build and issue"

--- a/.github/workflows/track-buildx-releases.yml
+++ b/.github/workflows/track-buildx-releases.yml
@@ -60,7 +60,10 @@ jobs:
             --state all \
             --search "in:title Building Docker Buildx ${LATEST} for RISC-V64" \
             --json number,title \
-            --jq 'map(select(.title == "Building Docker Buildx '"${LATEST}"' for RISC-V64")) | .[0].number // empty')
+            --jq 'map(select(.title == "Building Docker Buildx '"${LATEST}"' for RISC-V64")) | .[0].number // empty') || {
+            echo "ERROR: gh issue list failed while checking duplicates for Docker Buildx ${LATEST}"
+            exit 1
+          }
 
           if [ -n "$EXISTING" ]; then
             echo "ℹ️ Tracking issue #$EXISTING already exists for Docker Buildx ${LATEST}, skipping build and issue"

--- a/.github/workflows/track-cagent-releases.yml
+++ b/.github/workflows/track-cagent-releases.yml
@@ -73,7 +73,10 @@ jobs:
             --state all \
             --search "in:title Building cagent ${LATEST} for RISC-V64" \
             --json number,title \
-            --jq 'map(select(.title == "Building cagent '"${LATEST}"' for RISC-V64")) | .[0].number // empty')
+            --jq 'map(select(.title == "Building cagent '"${LATEST}"' for RISC-V64")) | .[0].number // empty') || {
+            echo "ERROR: gh issue list failed while checking duplicates for cagent ${LATEST}"
+            exit 1
+          }
 
           if [ -n "$EXISTING" ]; then
             echo "ℹ️ Tracking issue #$EXISTING already exists for cagent ${LATEST}, skipping build and issue"

--- a/.github/workflows/track-cli-releases.yml
+++ b/.github/workflows/track-cli-releases.yml
@@ -65,7 +65,10 @@ jobs:
             --state all \
             --search "in:title Building Docker CLI ${LATEST} for RISC-V64" \
             --json number,title \
-            --jq 'map(select(.title == "Building Docker CLI '"${LATEST}"' for RISC-V64")) | .[0].number // empty')
+            --jq 'map(select(.title == "Building Docker CLI '"${LATEST}"' for RISC-V64")) | .[0].number // empty') || {
+            echo "ERROR: gh issue list failed while checking duplicates for Docker CLI ${LATEST}"
+            exit 1
+          }
 
           if [ -n "$EXISTING" ]; then
             echo "ℹ️ Tracking issue #$EXISTING already exists for Docker CLI ${LATEST}, skipping build and issue"

--- a/.github/workflows/track-compose-releases.yml
+++ b/.github/workflows/track-compose-releases.yml
@@ -60,7 +60,10 @@ jobs:
             --state all \
             --search "in:title Building Docker Compose ${LATEST} for RISC-V64" \
             --json number,title \
-            --jq 'map(select(.title == "Building Docker Compose '"${LATEST}"' for RISC-V64")) | .[0].number // empty')
+            --jq 'map(select(.title == "Building Docker Compose '"${LATEST}"' for RISC-V64")) | .[0].number // empty') || {
+            echo "ERROR: gh issue list failed while checking duplicates for Docker Compose ${LATEST}"
+            exit 1
+          }
 
           if [ -n "$EXISTING" ]; then
             echo "ℹ️ Tracking issue #$EXISTING already exists for Docker Compose ${LATEST}, skipping build and issue"

--- a/.github/workflows/track-moby-releases.yml
+++ b/.github/workflows/track-moby-releases.yml
@@ -54,7 +54,10 @@ jobs:
             --state all \
             --search "in:title Building Docker ${LATEST} for RISC-V64" \
             --json number,title \
-            --jq 'map(select(.title == "Building Docker '"${LATEST}"' for RISC-V64")) | .[0].number // empty')
+            --jq 'map(select(.title == "Building Docker '"${LATEST}"' for RISC-V64")) | .[0].number // empty') || {
+            echo "ERROR: gh issue list failed while checking duplicates for Docker ${LATEST}"
+            exit 1
+          }
 
           if [ -n "$EXISTING" ]; then
             echo "ℹ️ Tracking issue #$EXISTING already exists for Docker ${LATEST}, skipping build and issue"

--- a/.github/workflows/track-runner-releases.yml
+++ b/.github/workflows/track-runner-releases.yml
@@ -84,7 +84,10 @@ jobs:
             --state all \
             --search "in:title Update github-act-runner to $LATEST" \
             --json number,title \
-            --jq 'map(select(.title == "Update github-act-runner to '"$LATEST"'")) | .[0].number // empty')
+            --jq 'map(select(.title == "Update github-act-runner to '"$LATEST"'")) | .[0].number // empty') || {
+            echo "ERROR: gh issue list failed while checking duplicates for runner $LATEST"
+            exit 1
+          }
 
           if [ -n "$EXISTING" ]; then
             echo "ℹ️ Tracking issue #$EXISTING already exists for runner $LATEST, skipping update and issue"


### PR DESCRIPTION
## Summary
- All 7 release trackers now check for existing issues (open or closed) before creating new ones
- Prevents duplicate tracking issues when a build fails and the tracker re-triggers on the next daily run
- Affected trackers: moby, cli, compose, buildx, buildkit, cagent, runner

## Problem
The runner tracker created 8 duplicate issues for v0.12.0 and 2 for v0.12.2. The cagent tracker created 3 duplicates for v1.20.0. Any tracker that re-ran while a build was pending or failed would create a new issue each time.

## Fix
Each tracker now searches for existing issues by label and title before calling `gh issue create`. If a matching issue already exists (open or closed), it skips creation.

## Test plan
- [ ] Verify trackers still create issues for genuinely new releases
- [ ] Verify trackers skip issue creation when a matching issue already exists
- [ ] Run a tracker manually with `workflow_dispatch` to confirm no duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added duplicate-detection to release-tracking workflows so builds and tracking issues are skipped when a matching issue already exists.
  * Made build triggers conditional to run only for new, non-duplicated releases.
  * Added validation to ensure fetched release tags are present before proceeding.
  * Centralized and adjusted tracking-issue creation flow and messaging to run only when a new, non-duplicate release is detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->