### PR TITLE
fix(ci): actually run updatecli via explicit pipeline step

### DIFF
--- a/.github/workflows/updatecli-cagent.yml
+++ b/.github/workflows/updatecli-cagent.yml
@@ -28,12 +28,11 @@ jobs:
             && sudo apt install gh -y
           }
 
-      - name: Run UpdateCLI for cagent version updates
+      - name: Install Updatecli
         uses: updatecli/updatecli-action@v2
-        with:
-          command: apply
-          config: .updatecli.d/cagent.yaml
-          values: .updatecli.d/values.yaml
+
+      - name: Run UpdateCLI for cagent version updates
+        run: updatecli pipeline apply --config .updatecli.d/cagent.yaml --values .updatecli.d/values.yaml
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/updatecli-gentoo.yml
+++ b/.github/workflows/updatecli-gentoo.yml
@@ -28,12 +28,11 @@ jobs:
             && sudo apt install gh -y
           }
 
-      - name: Run UpdateCLI for Gentoo packages
+      - name: Install Updatecli
         uses: updatecli/updatecli-action@v2
-        with:
-          command: apply
-          config: .updatecli.d/gentoo-*.yaml
-          values: .updatecli.d/values.yaml
+
+      - name: Run UpdateCLI for Gentoo packages
+        run: updatecli pipeline apply --config .updatecli.d/gentoo-containerd.yaml --config .updatecli.d/gentoo-docker-cli.yaml --config .updatecli.d/gentoo-docker-compose.yaml --config .updatecli.d/gentoo-runc.yaml --config .updatecli.d/gentoo-tini.yaml --values .updatecli.d/values.yaml
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Both updatecli workflows (`updatecli-cagent.yml`, `updatecli-gentoo.yml`) passed `command`/`config`/`values` inputs to `updatecli/updatecli-action`. That action only *installs* updatecli, it has no such inputs, so they were silently ignored and updatecli never actually ran. The jobs were no-ops.

Replaced the input-based call with an explicit `run: updatecli pipeline apply` step. The gentoo manifests are passed via repeated `--config` (updatecli doesn't expand globs, and `--config <dir>` would wrongly include `values.yaml`). Used the `pipeline` subcommand since the top-level `apply` is now deprecated; the action installs the latest binary, so it's available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated workflow configuration for dependency update automation to use direct command execution instead of action inputs, improving consistency and maintainability in CI/CD pipeline definitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gounthar/docker-for-riscv64/pull/406?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->