### PR TITLE
fix(ci): make updatecli workflows actually run (backslash-free manifests + x-access-token auth)

### DIFF
--- a/.updatecli.d/cagent.yaml
+++ b/.updatecli.d/cagent.yaml
@@ -27,7 +27,7 @@ sources:
         latest: true
       versionfilter:
         kind: regex
-        pattern: '^v(\d+\.\d+\.\d+)$'
+        pattern: '^v([0-9]+[.][0-9]+[.][0-9]+)$'
     transformers:
       - trimprefix: "v"
 
@@ -73,7 +73,7 @@ targets:
     sourceid: cagentRelease
     spec:
       file: "debian-cagent/changelog"
-      matchpattern: '^cagent \(([0-9]+\.[0-9]+\.[0-9]+)-1\)'
+      matchpattern: '^cagent [(]([0-9]+[.][0-9]+[.][0-9]+)-1[)]'
       replacepattern: 'cagent ({{ source `cagentRelease` }}-1)'
     scmid: default
 
@@ -83,7 +83,7 @@ targets:
     sourceid: cagentRelease
     spec:
       file: "rpm-cagent/cagent.spec"
-      matchpattern: '^Version:\s+([0-9]+\.[0-9]+\.[0-9]+)'
+      matchpattern: '^Version:[[:space:]]+([0-9]+[.][0-9]+[.][0-9]+)'
       replacepattern: 'Version:        {{ source `cagentRelease` }}'
     scmid: default
 

--- a/.updatecli.d/gentoo-containerd.yaml
+++ b/.updatecli.d/gentoo-containerd.yaml
@@ -29,7 +29,7 @@ sources:
         latest: true
       versionfilter:
         kind: regex
-        pattern: '^v(\d+\.\d+\.\d+)-riscv64$'
+        pattern: '^v([0-9]+[.][0-9]+[.][0-9]+)-riscv64$'
     transformers:
       - trimprefix: "v"
       - trimsuffix: "-riscv64"
@@ -44,7 +44,7 @@ sources:
       command: |
         DOCKER_VERSION="{{ source `dockerRelease` }}"
         # Get containerd version from release assets
-        gh release view "v${DOCKER_VERSION}-riscv64" --repo gounthar/docker-for-riscv64 --json assets --jq '.assets[].name' | grep "containerd-" | grep ".rpm" | head -1 | sed -E 's/containerd-([0-9]+\.[0-9]+\.[0-9]+)-.*/\1/'
+        gh release view "v${DOCKER_VERSION}-riscv64" --repo gounthar/docker-for-riscv64 --json assets --jq '.assets[].name' | grep "containerd-" | grep ".rpm" | grep -oE '[0-9]+[.][0-9]+[.][0-9]+' | head -1
       environments:
         - name: PATH
         - name: GITHUB_TOKEN
@@ -73,7 +73,7 @@ targets:
     sourceid: containerdVersion
     spec:
       file: "generate-gentoo-overlay-modular.sh"
-      matchpattern: 'CONTAINERD_VERSION="([0-9]+\.[0-9]+\.[0-9]+)"'
+      matchpattern: 'CONTAINERD_VERSION="([0-9]+[.][0-9]+[.][0-9]+)"'
       replacepattern: 'CONTAINERD_VERSION="{{ source `containerdVersion` }}"'
     scmid: default
 

--- a/.updatecli.d/gentoo-docker-cli.yaml
+++ b/.updatecli.d/gentoo-docker-cli.yaml
@@ -27,7 +27,7 @@ sources:
         latest: true
       versionfilter:
         kind: regex
-        pattern: '^cli-v(\d+\.\d+\.\d+)-riscv64$'
+        pattern: '^cli-v([0-9]+[.][0-9]+[.][0-9]+)-riscv64$'
     transformers:
       - trimprefix: "cli-v"
       - trimsuffix: "-riscv64"
@@ -53,7 +53,7 @@ targets:
     sourceid: cliRelease
     spec:
       file: "generate-gentoo-overlay-modular.sh"
-      matchpattern: 'CLI_VERSION="([0-9]+\.[0-9]+\.[0-9]+)"'
+      matchpattern: 'CLI_VERSION="([0-9]+[.][0-9]+[.][0-9]+)"'
       replacepattern: 'CLI_VERSION="{{ source `cliRelease` }}"'
     scmid: default
 

--- a/.updatecli.d/gentoo-docker-compose.yaml
+++ b/.updatecli.d/gentoo-docker-compose.yaml
@@ -27,7 +27,7 @@ sources:
         latest: true
       versionfilter:
         kind: regex
-        pattern: '^compose-v(\d+\.\d+\.\d+)-riscv64$'
+        pattern: '^compose-v([0-9]+[.][0-9]+[.][0-9]+)-riscv64$'
     transformers:
       - trimprefix: "compose-v"
       - trimsuffix: "-riscv64"
@@ -53,7 +53,7 @@ targets:
     sourceid: composeRelease
     spec:
       file: "generate-gentoo-overlay-modular.sh"
-      matchpattern: 'COMPOSE_VERSION="([0-9]+\.[0-9]+\.[0-9]+)"'
+      matchpattern: 'COMPOSE_VERSION="([0-9]+[.][0-9]+[.][0-9]+)"'
       replacepattern: 'COMPOSE_VERSION="{{ source `composeRelease` }}"'
     scmid: default
 

--- a/.updatecli.d/gentoo-runc.yaml
+++ b/.updatecli.d/gentoo-runc.yaml
@@ -27,7 +27,7 @@ sources:
         latest: true
       versionfilter:
         kind: regex
-        pattern: '^v(\d+\.\d+\.\d+)-riscv64$'
+        pattern: '^v([0-9]+[.][0-9]+[.][0-9]+)-riscv64$'
     transformers:
       - trimprefix: "v"
       - trimsuffix: "-riscv64"
@@ -40,7 +40,7 @@ sources:
     spec:
       command: |
         DOCKER_VERSION="{{ source `dockerRelease` }}"
-        gh release view "v${DOCKER_VERSION}-riscv64" --repo gounthar/docker-for-riscv64 --json assets --jq '.assets[].name' | grep "runc-" | grep ".rpm" | head -1 | sed -E 's/runc-([0-9]+\.[0-9]+\.[0-9]+)-.*/\1/'
+        gh release view "v${DOCKER_VERSION}-riscv64" --repo gounthar/docker-for-riscv64 --json assets --jq '.assets[].name' | grep "runc-" | grep ".rpm" | grep -oE '[0-9]+[.][0-9]+[.][0-9]+' | head -1
       environments:
         - name: PATH
         - name: GITHUB_TOKEN
@@ -67,7 +67,7 @@ targets:
     sourceid: runcVersion
     spec:
       file: "generate-gentoo-overlay-modular.sh"
-      matchpattern: 'RUNC_VERSION="([0-9]+\.[0-9]+\.[0-9]+)"'
+      matchpattern: 'RUNC_VERSION="([0-9]+[.][0-9]+[.][0-9]+)"'
       replacepattern: 'RUNC_VERSION="{{ source `runcVersion` }}"'
     scmid: default
 

--- a/.updatecli.d/gentoo-tini.yaml
+++ b/.updatecli.d/gentoo-tini.yaml
@@ -27,7 +27,7 @@ sources:
         latest: true
       versionfilter:
         kind: regex
-        pattern: '^tini-v(\d+\.\d+\.\d+)-riscv64$'
+        pattern: '^tini-v([0-9]+[.][0-9]+[.][0-9]+)-riscv64$'
     transformers:
       - trimprefix: "tini-v"
       - trimsuffix: "-riscv64"
@@ -66,7 +66,7 @@ targets:
     sourceid: tiniRelease
     spec:
       file: "generate-gentoo-overlay-modular.sh"
-      matchpattern: 'TINI_VERSION="([0-9]+\.[0-9]+\.[0-9]+)"'
+      matchpattern: 'TINI_VERSION="([0-9]+[.][0-9]+[.][0-9]+)"'
       replacepattern: 'TINI_VERSION="{{ source `tiniRelease` }}"'
     scmid: default
 

--- a/.updatecli.d/values.yaml
+++ b/.updatecli.d/values.yaml
@@ -5,7 +5,11 @@
 github:
   user: "github-actions[bot]"
   email: "github-actions[bot]@users.noreply.github.com"
-  username: "github-actions[bot]"
+  # Git HTTPS basic-auth username for clone/push. For a GITHUB_TOKEN this
+  # must be "x-access-token" (what actions/checkout uses); "github-actions[bot]"
+  # is rejected with "HTTP Basic: Access denied". Commit authorship still uses
+  # the user/email above.
+  username: "x-access-token"
   # Token: manifests use {{ requiredEnv .github.token }} which reads
   # the environment variable named by this value
   token: "UPDATECLI_GITHUB_TOKEN"


### PR DESCRIPTION
Fixes two separate problems that surfaced when the UpdateCLI workflows finally reached their update/PR phase (a new upstream release made the pipeline conditions pass for the first time in months — daily runs had been short-circuiting in ~10s).

## 1. `cfg:N: unexpected "\\" in operand` (the real, recurring failure)

updatecli calls `Config.Update()` for each DAG vertex, which re-marshals the config spec to YAML and re-parses it as a Go template (named `cfg`). When a manifest combines an `actions` pull-request `description` (marshalled as a double-quoted scalar because of the emoji and newlines) with regex backslashes elsewhere (`\d`, `\.`, the `sed` `\1` backreference, `\s`), that second parse blows up and every pipeline reaching the update phase fails:

```
ERROR: something went wrong in "target#updateGenerationScript" :
	update pipeline: template: cfg:8: unexpected "\\" in operand
```

This reproduces even when the clone succeeds, so it is independent of auth. Failing runs: [26398798665](https://github.com/gounthar/docker-for-riscv64/actions/runs/26398798665) (Gentoo), and the UpdateCLI cagent run on the same day.

Fix: rewrite every regex/sed pattern backslash-free across all 5 Gentoo manifests + cagent:
- `\d` → `[0-9]`, `\.` → `[.]`, `\s` → `[[:space:]]`, `\(`/`\)` → `[(]`/`[)]`
- the two `sed -E 's/<pkg>-(...)-.*/\1/'` version extractions → `grep -oE '[0-9]+[.][0-9]+[.][0-9]+' | head -1` (the line is already filtered to the package rpm asset, so the first `N.N.N` is the version — behaviour unchanged).

## 2. Clone auth hardening

The updatecli github SCM authenticated git clone/push as `github-actions[bot]` with the workflow `GITHUB_TOKEN`. That combination can be rejected over HTTPS basic auth (`HTTP Basic: Access denied`). Set the auth username to `x-access-token` (the canonical value for `GITHUB_TOKEN`, used internally by `actions/checkout`). Commit authorship is unchanged — `user`/`email` remain `github-actions[bot]`.

## Verification

- Root cause traced through updatecli source (`pkg/core/config/main.go` `Update()` → `template.New("cfg")`; `pkg/core/pipeline/main.go` `runFlowCallback` → `p.Update()`).
- Backslash-free manifests get past the parse in isolated tests; backslash variants reproduce the error.
- `yamllint` clean on the changed manifests.
- End-to-end confirmation should come from a `workflow_dispatch` run of "UpdateCLI - Gentoo Packages" after merge (local verification was limited by network/clone constraints).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub HTTPS authentication value to use token-based username for automated operations.
  * Improved upstream release/version detection across multiple update workflows to more reliably match dotted semantic versions, reducing false matches and update failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gounthar/docker-for-riscv64/pull/407?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->