### PR TITLE
fix(ci): select highest matching release, not GitHub latest flag

### DIFF
--- a/.updatecli.d/cagent.yaml
+++ b/.updatecli.d/cagent.yaml
@@ -23,8 +23,6 @@ sources:
       owner: "docker"
       repository: "cagent"
       token: "{{ requiredEnv .github.token }}"
-      typefilter:
-        latest: true
       versionfilter:
         kind: regex
         pattern: '^v([0-9]+[.][0-9]+[.][0-9]+)$'

--- a/.updatecli.d/gentoo-containerd.yaml
+++ b/.updatecli.d/gentoo-containerd.yaml
@@ -25,8 +25,6 @@ sources:
       owner: "gounthar"
       repository: "docker-for-riscv64"
       token: "{{ requiredEnv .github.token }}"
-      typefilter:
-        latest: true
       versionfilter:
         kind: regex
         pattern: '^v([0-9]+[.][0-9]+[.][0-9]+)-riscv64$'

--- a/.updatecli.d/gentoo-docker-cli.yaml
+++ b/.updatecli.d/gentoo-docker-cli.yaml
@@ -23,8 +23,6 @@ sources:
       owner: "gounthar"
       repository: "docker-for-riscv64"
       token: "{{ requiredEnv .github.token }}"
-      typefilter:
-        latest: true
       versionfilter:
         kind: regex
         pattern: '^cli-v([0-9]+[.][0-9]+[.][0-9]+)-riscv64$'

--- a/.updatecli.d/gentoo-docker-compose.yaml
+++ b/.updatecli.d/gentoo-docker-compose.yaml
@@ -23,8 +23,6 @@ sources:
       owner: "gounthar"
       repository: "docker-for-riscv64"
       token: "{{ requiredEnv .github.token }}"
-      typefilter:
-        latest: true
       versionfilter:
         kind: regex
         pattern: '^compose-v([0-9]+[.][0-9]+[.][0-9]+)-riscv64$'

--- a/.updatecli.d/gentoo-runc.yaml
+++ b/.updatecli.d/gentoo-runc.yaml
@@ -23,8 +23,6 @@ sources:
       owner: "gounthar"
       repository: "docker-for-riscv64"
       token: "{{ requiredEnv .github.token }}"
-      typefilter:
-        latest: true
       versionfilter:
         kind: regex
         pattern: '^v([0-9]+[.][0-9]+[.][0-9]+)-riscv64$'

--- a/.updatecli.d/gentoo-tini.yaml
+++ b/.updatecli.d/gentoo-tini.yaml
@@ -23,8 +23,6 @@ sources:
       owner: "gounthar"
       repository: "docker-for-riscv64"
       token: "{{ requiredEnv .github.token }}"
-      typefilter:
-        latest: true
       versionfilter:
         kind: regex
         pattern: '^tini-v([0-9]+[.][0-9]+[.][0-9]+)-riscv64$'


### PR DESCRIPTION
## Problem

The `githubrelease` sources used `typefilter: latest: true`, which only considers the release GitHub flags as **Latest**. When a dated `-dev` build is Latest (e.g. `cli-v20260524-dev`), the semver regex matches nothing and the source fails:

```
filtering github release version: no version found matching pattern "^v([0-9]+[.][0-9]+[.][0-9]+)-riscv64$"
```

That breaks every pipeline whenever a dev build is the latest release — which is why the dispatched run still failed after the emoji fix (#408).

## Fix

Drop `typefilter: latest: true` from all six sources. The regex versionfilter is then applied across **all** releases and returns the **highest matching** version, ignoring `-dev` tags.

## Verification (live repo, current tags)

| source | resolves to |
|---|---|
| containerd / runc (`^v…-riscv64$`) | `v29.5.2-riscv64` |
| docker-cli (`^cli-v…-riscv64$`) | `cli-v29.5.2-riscv64` |
| compose (`^compose-v…-riscv64$`) | `compose-v5.1.4-riscv64` |
| tini (`^tini-v…-riscv64$`) | `tini-v0.19.0-riscv64` |
| cagent (`^v…$`, upstream) | `v1.65.0` |

`-dev` tags (currently GitHub's "Latest") are correctly skipped.

A `versionfilter: kind: semver` was considered and rejected — the prefixed tags (`cli-v…`, `compose-v…`) don't parse as plain semver and it mis-selects (it returned `v1.0.0` in testing).

Together with #408 (emoji removal, fixed the `cfg:N: unexpected "\\" in operand` parse error), this makes the UpdateCLI workflows run end-to-end again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency tracking configurations to use semantic versioning patterns for release filtering instead of simple "latest" selection, improving precision for upstream source matching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gounthar/docker-for-riscv64/pull/409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->