### PR TITLE
chore(gentoo): update package versions

### DIFF
--- a/generate-gentoo-overlay-modular.sh
+++ b/generate-gentoo-overlay-modular.sh
@@ -16,8 +16,8 @@ set -e
 DOCKER_VERSION="28.5.1"
 CLI_VERSION="29.5.2"
 COMPOSE_VERSION="5.1.4"
-CONTAINERD_VERSION="1.7.28"
-RUNC_VERSION="1.3.0"
+CONTAINERD_VERSION=""
+RUNC_VERSION=""
 TINI_VERSION="0.19.0"
 
 # Print usage and the current default versions (interpolated from the constants above).


### PR DESCRIPTION
Automated Gentoo overlay version bumps from the latest RISC-V64 releases.

Changed in generate-gentoo-overlay-modular.sh:

```
-CONTAINERD_VERSION="1.7.28"
-RUNC_VERSION="1.3.0"
+CONTAINERD_VERSION=""
+RUNC_VERSION=""
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified default version handling in the overlay generation script. Users may need to explicitly specify versions for container runtime components where defaults were previously applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->