### PR TITLE
fix(updatecli): guard gentoo containerd/runc sources against empty versions

### DIFF
--- a/.updatecli.d/gentoo-containerd.yaml
+++ b/.updatecli.d/gentoo-containerd.yaml
@@ -29,8 +29,16 @@ sources:
     spec:
       command: |
         DOCKER_VERSION="{{ source `dockerRelease` }}"
-        # Get containerd version from release assets
-        gh release view "v${DOCKER_VERSION}-riscv64" --repo gounthar/docker-for-riscv64 --json assets --jq '.assets[].name' | grep "containerd-" | grep ".rpm" | grep -oE '[0-9]+[.][0-9]+[.][0-9]+' | head -1
+        # Extract the containerd version from the release's RPM asset name.
+        VERSION=$(gh release view "v${DOCKER_VERSION}-riscv64" --repo gounthar/docker-for-riscv64 --json assets --jq '.assets[].name' | grep "containerd-" | grep ".rpm" | grep -oE '[0-9]+[.][0-9]+[.][0-9]+' | head -1)
+        # Fail instead of emitting an empty value when the RPM is not published yet
+        # (e.g. the release exists but its assets are still uploading). An empty
+        # source would otherwise overwrite a valid CONTAINERD_VERSION with an empty string.
+        if [ -z "$VERSION" ]; then
+          echo "No containerd RPM version found in v${DOCKER_VERSION}-riscv64 assets (assets still uploading?)" >&2
+          exit 1
+        fi
+        echo "$VERSION"
       environments:
         - name: PATH
         - name: GITHUB_TOKEN
@@ -45,7 +53,7 @@ conditions:
     spec:
       command: |
         DOCKER_VERSION="{{ source `dockerRelease` }}"
-        gh release view "v${DOCKER_VERSION}-riscv64" --repo gounthar/docker-for-riscv64 --json assets --jq '.assets[].name' | grep -q "^containerd$"
+        gh release view "v${DOCKER_VERSION}-riscv64" --repo gounthar/docker-for-riscv64 --json assets --jq '.assets[].name' | grep "containerd-" | grep -q ".rpm"
       environments:
         - name: PATH
         - name: GITHUB_TOKEN

--- a/.updatecli.d/gentoo-runc.yaml
+++ b/.updatecli.d/gentoo-runc.yaml
@@ -26,7 +26,16 @@ sources:
     spec:
       command: |
         DOCKER_VERSION="{{ source `dockerRelease` }}"
-        gh release view "v${DOCKER_VERSION}-riscv64" --repo gounthar/docker-for-riscv64 --json assets --jq '.assets[].name' | grep "runc-" | grep ".rpm" | grep -oE '[0-9]+[.][0-9]+[.][0-9]+' | head -1
+        # Extract the runc version from the release's RPM asset name.
+        VERSION=$(gh release view "v${DOCKER_VERSION}-riscv64" --repo gounthar/docker-for-riscv64 --json assets --jq '.assets[].name' | grep "runc-" | grep ".rpm" | grep -oE '[0-9]+[.][0-9]+[.][0-9]+' | head -1)
+        # Fail instead of emitting an empty value when the RPM is not published yet
+        # (e.g. the release exists but its assets are still uploading). An empty
+        # source would otherwise overwrite a valid RUNC_VERSION with an empty string.
+        if [ -z "$VERSION" ]; then
+          echo "No runc RPM version found in v${DOCKER_VERSION}-riscv64 assets (assets still uploading?)" >&2
+          exit 1
+        fi
+        echo "$VERSION"
       environments:
         - name: PATH
         - name: GITHUB_TOKEN
@@ -40,7 +49,7 @@ conditions:
     spec:
       command: |
         DOCKER_VERSION="{{ source `dockerRelease` }}"
-        gh release view "v${DOCKER_VERSION}-riscv64" --repo gounthar/docker-for-riscv64 --json assets --jq '.assets[].name' | grep -q "^runc$"
+        gh release view "v${DOCKER_VERSION}-riscv64" --repo gounthar/docker-for-riscv64 --json assets --jq '.assets[].name' | grep "runc-" | grep -q ".rpm"
       environments:
         - name: PATH
         - name: GITHUB_TOKEN


### PR DESCRIPTION
## Problem

The `containerd` and `runc` Gentoo manifests derive their version from the release's RPM asset name using a `kind: shell` source:

```
gh release view "v${DOCKER_VERSION}-riscv64" ... | grep "containerd-" | grep ".rpm" | grep -oE '[0-9]+...' | head -1
```

When a new Docker release has just been **created but its RPM assets are still uploading**, that command returns nothing. UpdateCLI then treats the empty output as a valid source value and the file target overwrites the version with an empty string:

```
-CONTAINERD_VERSION="1.7.28"   +CONTAINERD_VERSION=""
-RUNC_VERSION="1.3.0"          +RUNC_VERSION=""
```

That is exactly what #424 contains. An empty version would break `generate-containerd-ebuild.sh`/`generate-runc-ebuild.sh` downstream.

The existing `condition` only checked for the raw `containerd`/`runc` binary, which is uploaded **before** the RPM, so it did not gate against this race.

## Fix

- **Source**: capture the extracted version, and `exit 1` when it is empty so UpdateCLI skips the target instead of writing an empty value.
- **Condition**: require the RPM asset (`grep "containerd-" | grep -q ".rpm"`) that the source actually parses, rather than the raw binary.

Either change alone prevents the empty write; together the run skips cleanly while assets are still uploading and bumps the version once the RPM is present.

Context: supersedes the bad output in #424 (left open for review).