### PR TITLE
chore(gentoo): update package versions

### DIFF
--- a/generate-gentoo-overlay-modular.sh
+++ b/generate-gentoo-overlay-modular.sh
@@ -14,7 +14,7 @@ set -e
 
 # Default versions (single source of truth)
 DOCKER_VERSION="28.5.1"
-CLI_VERSION="29.7.1"
+CLI_VERSION="29.7.2"
 COMPOSE_VERSION="5.4.0"
 CONTAINERD_VERSION="1.7.28"
 RUNC_VERSION="1.3.0"


### PR DESCRIPTION
Automated Gentoo overlay version bumps from the latest RISC-V64 releases.

Changed in generate-gentoo-overlay-modular.sh:

```
-CLI_VERSION="29.7.1"
+CLI_VERSION="29.7.2"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default Docker CLI version to 29.7.2 in generated package metadata, dependencies, and documentation examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->